### PR TITLE
Quickfix - Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the [Flow Deveroper Documentation](https://docs.onflow.org) has a guide on how t
 We built the Flow Playground as a static website or typical "JAM stack" website because of these properties:
 
 - Portability. It is easy to move a static website GUI between platforms if desired
-- We want to have the ability to deploy the Playground on peer-tp-peer networks like IPFS or DAT
+- We want to have the ability to deploy the Playground on peer-to-peer networks like IPFS or DAT
 - Fast build and deploy cycles
 - We want to maximize the amount of potential contributions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome
-The Flow Playground is the best way to learn and try Cadence, for newcomers to Flow
-The [Flow Deveroper Documentation](https://docs.onflow.org) has a guide on how to use the Playground
+The Flow Playground is the best way to learn and try Cadence. For newcomers to Flow
+The [Flow Deveroper Documentation](https://docs.onflow.org) has a guide on how to use the Playground.
 
 ## Philosophy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome
 The Flow Playground is the best way to learn and try Cadence. For newcomers to Flow
-The [Flow Deveroper Documentation](https://docs.onflow.org) has a guide on how to use the Playground.
+the [Flow Deveroper Documentation](https://docs.onflow.org) has a guide on how to use the Playground.
 
 ## Philosophy
 


### PR DESCRIPTION
- typo in word `peer-to-peer`. 
- first sentence was looking better if split with dot instead of comma 🧐
- I believe, article "the" in front of `Flow Deveroper Documentation` link is supposed to be lowercase