### PR TITLE
Remove multi flag from AccountPicker components

### DIFF
--- a/src/components/AccountAvatars.tsx
+++ b/src/components/AccountAvatars.tsx
@@ -45,16 +45,11 @@ export const AvatarList: React.FC = ({ children }) => {
 const noop = (): void => {};
 
 const AccountAvatars: React.FC<{
-  multi?: boolean;
   selectedAccounts: number[];
   onChange: (selected: number) => void;
   project: Project;
   accounts: Account[];
-}> = ({ multi, selectedAccounts, accounts, project, onChange }) => {
-  if (!multi) {
-    throw new Error("Must include multi prop.");
-  }
-
+}> = ({ selectedAccounts, accounts, project, onChange }) => {
   const { theme } = useThemeUI();
   
   return (

--- a/src/components/AccountPicker.tsx
+++ b/src/components/AccountPicker.tsx
@@ -51,7 +51,6 @@ const AccountPicker: React.FC<AccountPickerProps> = ({
         }}
       >
         <AccountAvatars
-          multi={true}
           project={project}
           accounts={accounts}
           selectedAccounts={selected}
@@ -68,7 +67,6 @@ const AccountPicker: React.FC<AccountPickerProps> = ({
         }}
       >
         <AccountSigners 
-          multi={true}
           project={project}
           accounts={accounts}
           selectedAccounts={selected}

--- a/src/components/AccountSigners.tsx
+++ b/src/components/AccountSigners.tsx
@@ -28,16 +28,11 @@ export const Outline: React.FC = ({ children }) => {
 };
 
 const AccountSigners: React.FC<{
-  multi?: boolean;
   selectedAccounts: number[];
   onChange: (selected: number) => void;
   project: Project;
   accounts: Account[];
-}> = ({ multi, selectedAccounts, accounts, project, onChange }) => {
-  if (!multi) {
-    throw new Error("Must include multi prop.");
-  }
-
+}> = ({ selectedAccounts, accounts, project, onChange }) => {
   const { theme } = useThemeUI();
   const renderOutlines = () => {
     const outlines = [];


### PR DESCRIPTION
Port dapperlabs/flow-playground#112

> just a small update to remove the `multi` flag (since it is no longer used) in the `AccountPicker` components (`AccountAvatars` and `AccountSigners)`