### PR TITLE
Replace CRLF with LF

### DIFF
--- a/src/components/CadenceEditor.tsx
+++ b/src/components/CadenceEditor.tsx
@@ -65,7 +65,8 @@ class CadenceEditor extends React.Component<{
       );
 
       this._subscription = this.editor.onDidChangeModelContent((event: any) => {
-        this.props.onChange(this.editor.getValue(), event);
+        const code = this.editor.getValue().replace(/\r\n/g, '\n')
+        this.props.onChange(code, event);
       });
 
       const state = this.getOrCreateEditorState(


### PR DESCRIPTION
Until Cadence is updated Playground API is updated to 0.8.0, which contains a fix for handling CRLF line endings in the parser, the Playground has problems with line endings when used on Windows.

Replace all CRLF with LF line endings.