### PR TITLE
Fix yup dependency and lock file sync issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reset-css": "^5.0.1",
     "styled-components": "^5.0.1",
     "styled-reset": "^4.2.1",
-    "yup": "^0.28.1"
+    "yup": "^0.29.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.12.1",
@@ -77,11 +77,18 @@
     "@types/webpack-env": "^1.14.0",
     "css-loader": "^3.4.2",
     "dotenv-webpack": "^1.7.0",
+    "eslint": "^4.18.2",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-loader": "^2.0.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.7.0",
     "file-loader": "^5.0.2",
     "fs-extra": "^8.1.0",
     "js-string-escape": "^1.0.1",
     "lodash.escaperegexp": "^4.1.2",
     "monaco-editor-webpack-plugin": "^1.9.0",
+    "prettier": "^1.11.1",
     "react-hot-loader": "^4.12.11",
     "replace-in-file": "^5.0.2",
     "serve": "^11.1.0",
@@ -90,14 +97,7 @@
     "theme-ui": "^0.3.1",
     "typescript": "^3.7.5",
     "webpack": "^4.42.0",
-    "webpack-merge": "^4.2.2",
-    "eslint": "^4.18.2",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-loader": "^2.0.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-prettier": "^2.6.0",
-    "eslint-plugin-react": "^7.7.0",
-    "prettier": "^1.11.1"
+    "webpack-merge": "^4.2.2"
   },
   "snyk": true
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "isomorphic-fetch": "^2.2.1",
     "mixpanel-browser": "^2.34.0",
     "monaco-editor": "^0.20.0",
+    "property-expr": "2.0.3",
     "react": "^16.9.0",
     "react-avataaars": "^0.2.3",
     "react-dom": "^16.9.0",
@@ -98,6 +99,9 @@
     "typescript": "^3.7.5",
     "webpack": "^4.42.0",
     "webpack-merge": "^4.2.2"
+  },
+  "resolutions": {
+    "property-expr": "2.0.3"
   },
   "snyk": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,7 +1010,6 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-
 "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9372,10 +9372,10 @@ prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, 
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-property-expr@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.2.tgz#fff2a43919135553a3bc2fdd94bdb841965b2330"
-  integrity sha512-bc/5ggaYZxNkFKj374aLbEDqVADdYaLcFo8XBkishUWbaAdjlphaBFns9TvRA2pUseVL/wMFmui9X3IdNDU37g==
+property-expr@2.0.3, property-expr@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.3.tgz#0a3fce936515da358aca0b74d5844a3dc34139bd"
+  integrity sha512-TEMKBo6s4gZUKmNYwaMkS2JdDxdWgUijW/U/jLAOHVyLZfU1KHXv+mC1J9gkfGOr8532XHqMJytko1lSjc0kmw==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
Synk updated the lock file in #52, but for whatever reason did not update the `package.json` file like in its other dependency update PRs.

Manually update the `package.json` file to bring both files back in sync.