### PR TITLE
Synchronize labels from YAML file

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,57 @@
+- color: fbca04
+  description: ""
+  name: Breaking Change
+- color: 3E4B9E
+  description: ""
+  name: Epic
+- color: 0e8a16
+  description: ""
+  name: Feature
+- color: d4c5f9
+  description: ""
+  name: Feedback
+- color: 1d76db
+  description: ""
+  name: Improvement
+- color: efbd7f
+  description: ""
+  name: Needs Definition
+- color: f99875
+  description: ""
+  name: Needs Estimation
+- color: efa497
+  description: ""
+  name: Needs Test Cases
+- color: fcadab
+  description: ""
+  name: P-High
+- color: bfd4f2
+  description: ""
+  name: P-Low
+- color: ddcd3e
+  description: ""
+  name: P-Medium
+- color: CCCCCC
+  description: ""
+  name: Technical Debt
+- color: d73a4a
+  description: Something isn't working
+  name: Bug
+- color: c2e0c6
+  description: ""
+  name: Bugfix
+- color: cfd3d7
+  description: This issue or pull request already exists
+  name: Duplicate
+- color: 7057ff
+  description: Good for newcomers
+  name: Good First Issue
+- color: d876e3
+  description: Further information is requested
+  name: Question
+- color: 0075ca
+  description: Improvements or additions to documentation
+  name: Documentation
+- color: 5319e7
+  description: ""
+  name: S-Playground

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,19 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - sync-labels
+    paths:
+      - .github/labels.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,7 +3,7 @@ name: Sync Labels
 on:
   push:
     branches:
-      - sync-labels
+      - master
     paths:
       - .github/labels.yml
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,7 +3,7 @@ name: Sync Labels
 on:
   push:
     branches:
-      - sync-labels
+      - sync-labels2
     paths:
       - .github/labels.yml
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,7 +3,7 @@ name: Sync Labels
 on:
   push:
     branches:
-      - sync-labels2
+      - sync-labels
     paths:
       - .github/labels.yml
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,10 +3,9 @@ name: Sync Labels
 on:
   push:
     branches:
-      - sync-labels
+      - master
     paths:
       - .github/labels.yml
-      - .github/workflows/sync-labels.yml
 
 jobs:
   build:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -3,9 +3,10 @@ name: Sync Labels
 on:
   push:
     branches:
-      - master
+      - sync-labels
     paths:
       - .github/labels.yml
+      - .github/workflows/sync-labels.yml
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This PR adds a workflow for the `micnncim/action-label-syncer` action, which automatically synchronizes repository labels from a YAML file.