### PR TITLE
Use @onflow/cadence-language-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,6 +4786,14 @@
         }
       }
     },
+    "@onflow/cadence-language-server": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@onflow/cadence-language-server/-/cadence-language-server-0.12.4.tgz",
+      "integrity": "sha512-qpVYhRyI0BTKgShZFaYoWtYk+6nhJeFPCkj2MtUJTvomSsdMu8J1fPy1PP/QbkyJc4fPBz4lbcfYtoFuskK/SQ==",
+      "requires": {
+        "vscode-jsonrpc": "^5.0.1"
+      }
+    },
     "@reach/router": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
+    "@onflow/cadence-language-server": "^0.12.4",
     "@reach/router": "^1.3.4",
     "@types/file-saver": "^2.0.1",
     "apollo-cache-inmemory": "^1.6.6",

--- a/src/util/language-server.ts
+++ b/src/util/language-server.ts
@@ -58,7 +58,7 @@ export class CadenceLanguageServer {
       return
     }
 
-    const wasm = await fetch("./languageserver.wasm")
+    const wasm = await fetch("./cadence-language-server.wasm")
     const go = new Go()
     const module = await WebAssembly.instantiateStreaming(wasm, go.importObject)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: 'public', to: '.' },
+        { from: 'node_modules/@onflow/cadence-language-server/dist/cadence-language-server.wasm', to: '.'}
       ],
       options: {
         concurrency: 100,


### PR DESCRIPTION
## Description

Use the NPM package for the language server instead of storing the large WebAssembly binary in the repository.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

