### PR TITLE
Display a list of syntax errors

### DIFF
--- a/src/components/Arguments/SingleArgument/index.tsx
+++ b/src/components/Arguments/SingleArgument/index.tsx
@@ -16,7 +16,9 @@ const SingleArgument: React.FC<SingleArgumentProps> = ({ argument, error, onChan
         {name}
         <Type>{type}</Type>
       </Label>
-      <Input onChange={(event)=>{
+      <Input
+        name={`${name}-${type}`}
+        onChange={(event)=>{
         const {value} = event.target
         onChange(name,value)
       }}/>

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -20,15 +20,19 @@ import theme from "../../theme";
 
 export const ArgumentsTitle: React.FC<ArgumentsTitleProps> = (props) => {
   const { type, errors, expanded, setExpanded } = props
+
+  const hasErrors = errors > 0
+  const lineColor = hasErrors ? theme.colors.error : null
+
   return (
     <Heading>
-      <Title>
+      <Title lineColor={lineColor}>
         {type === EntityType.Account && "Contract Arguments"}
         {type === EntityType.TransactionTemplate && "Transaction Arguments"}
         {type === EntityType.ScriptTemplate && "Script Arguments"}
       </Title>
       <Controls>
-        {errors > 0 && <Badge><span>{errors}</span></Badge>}
+        {hasErrors && <Badge><span>{errors}</span></Badge>}
         <ToggleExpand className="icon" expanded={expanded} onClick={()=>setExpanded(!expanded)} />
       </Controls>
     </Heading>

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -115,7 +115,7 @@ export const Signers: React.FC<SignersProps> = (props) => {
       {enoughSigners &&
         <SignersError>
           <FaExclamationTriangle/>
-          "Not enough signers..."
+          Not enough signers...
         </SignersError>
       }
 

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -12,11 +12,14 @@ import {
   Title,
   SignersContainer,
   ToggleExpand,
-  SignersError
+  SignersError, SingleError, ErrorIndex, ErrorMessage
 } from "./styles";
 import { ArgumentsListProps, ArgumentsTitleProps, InteractionButtonProps } from "./types";
 import SingleArgument from "./SingleArgument";
 import theme from "../../theme";
+import {Stack} from "layout/Stack";
+import {CadenceSyntaxError} from "../../util/language-syntax-errors";
+import { ErrorListProps } from "./types";
 
 export const ArgumentsTitle: React.FC<ArgumentsTitleProps> = (props) => {
   const { type, errors, expanded, setExpanded } = props
@@ -50,6 +53,33 @@ export const ArgumentsList: React.FC<ArgumentsListProps> = ({list, errors, onCha
           : null
       })}
     </List>
+  )
+}
+
+export const ErrorsList: React.FC<ErrorListProps> = props => {
+  const { list, goTo, hideDecorations, hover } =  props
+  return (
+    <Stack>
+      <Heading>
+        <Title lineColor={theme.colors.error}>Syntax Errors</Title>
+      </Heading>
+      <List>
+        {list.map((item: CadenceSyntaxError, i) => {
+          return (
+            <SingleError
+              onClick={() => goTo(item.position)}
+              onMouseOver={() => hover(item.highlight)}
+              onMouseOut={() => hideDecorations()}
+            >
+              <ErrorIndex>
+                <span>{i + 1}</span>
+              </ErrorIndex>
+              <ErrorMessage>{item.message}</ErrorMessage>
+            </SingleError>
+          );
+        })}
+      </List>
+    </Stack>
   )
 }
 

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -99,6 +99,7 @@ export const Signers: React.FC<SignersProps> = (props) => {
         onChange={updateSelectedAccounts}
         maxSelection={maxSelection}
       />
+      {selected.length < maxSelection && <p>Not enough signers...</p>}
     </SignersContainer>
   )
 }

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -1,12 +1,22 @@
 import React from "react";
-import { FaArrowCircleRight } from "react-icons/fa";
+import { FaArrowCircleRight, FaExclamationTriangle } from "react-icons/fa";
 import { EntityType } from "providers/Project";
 import Button from "components/Button";
 import { useProject } from "providers/Project/projectHooks";
 import AccountPicker from "components/AccountPicker";
-import { Badge, Controls, Heading, List, Title, SignersContainer, ToggleExpand } from "./styles";
+import {
+  Badge,
+  Controls,
+  Heading,
+  List,
+  Title,
+  SignersContainer,
+  ToggleExpand,
+  SignersError
+} from "./styles";
 import { ArgumentsListProps, ArgumentsTitleProps, InteractionButtonProps } from "./types";
 import SingleArgument from "./SingleArgument";
+import theme from "../../theme";
 
 export const ArgumentsTitle: React.FC<ArgumentsTitleProps> = (props) => {
   const { type, errors, expanded, setExpanded } = props
@@ -87,11 +97,14 @@ export const Signers: React.FC<SignersProps> = (props) => {
     project
   } = useProject();
   const { accounts } = project;
-
   const { maxSelection, selected, updateSelectedAccounts } = props;
+
+  const enoughSigners = selected.length < maxSelection
+  const lineColor = enoughSigners ? theme.colors.error : null
+
   return(
     <SignersContainer>
-      <Title>Transaction Signers</Title>
+      <Title lineColor={lineColor}>Transaction Signers</Title>
       <AccountPicker
         project={project}
         accounts={accounts}
@@ -99,7 +112,13 @@ export const Signers: React.FC<SignersProps> = (props) => {
         onChange={updateSelectedAccounts}
         maxSelection={maxSelection}
       />
-      {selected.length < maxSelection && <p>Not enough signers...</p>}
+      {enoughSigners &&
+        <SignersError>
+          <FaExclamationTriangle/>
+          "Not enough signers..."
+        </SignersError>
+      }
+
     </SignersContainer>
   )
 }

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -6,44 +6,23 @@ import { useProject } from 'providers/Project/projectHooks';
 import {
   Account,
   ResultType,
-  useSetExecutionResultsMutation,
+  useSetExecutionResultsMutation
 } from 'api/apollo/generated/graphql';
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+import { ArgumentsProps } from "components/Arguments/types";
 
 import {
   ControlContainer,
   HoverPanel,
-  StatusMessage,
-  Heading,
-  Title,
-  ErrorsContainer,
-  SingleError,
-  ErrorIndex,
-  ErrorMessage,
+  StatusMessage
 } from './styles';
-import { Argument } from './types';
+
 import {
   ActionButton,
   ArgumentsList,
-  ArgumentsTitle,
+  ArgumentsTitle, ErrorsList,
   Signers,
 } from './components';
-import {
-  CadenceSyntaxError,
-  Highlight,
-} from '../../util/language-syntax-errors';
-import { Stack } from 'layout/Stack';
-import theme from '../../theme';
-
-type ArgumentsProps = {
-  type: EntityType;
-  list: Argument[];
-  signers: number;
-  syntaxErrors: CadenceSyntaxError[];
-  goTo: (position: monaco.IPosition) => void;
-  hover: (highlight: Highlight) => void;
-  hideDecorations: () => void;
-};
 
 const validateByType = (value: any, type: string) => {
   if (value.length === 0) {
@@ -58,7 +37,7 @@ const validateByType = (value: any, type: string) => {
 
     // Integers
     case type.includes('Int'): {
-      if (isNaN(value)) {
+      if (isNaN(value) || value === "") {
         return 'Should be a valid Integer number';
       }
       return null;
@@ -66,7 +45,7 @@ const validateByType = (value: any, type: string) => {
 
     // Words
     case type.includes('Word'): {
-      if (isNaN(value)) {
+      if (isNaN(value) || value === "") {
         return 'Should be a valid Word number';
       }
       return null;
@@ -74,7 +53,7 @@ const validateByType = (value: any, type: string) => {
 
     // Fixed Point
     case type.includes('Fix'): {
-      if (isNaN(value)) {
+      if (isNaN(value) || value === "") {
         return 'Should be a valid fixed point number';
       }
       return null;
@@ -102,7 +81,7 @@ const validateByType = (value: any, type: string) => {
 };
 
 const validate = (list: any, values: any) => {
-  const result = list.reduce((acc: any, item: any) => {
+  return list.reduce((acc: any, item: any) => {
     const { name, type } = item;
     const value = values[name];
     if (value) {
@@ -113,8 +92,6 @@ const validate = (list: any, values: any) => {
     }
     return acc;
   }, {});
-
-  return result;
 };
 
 const getLabel = (
@@ -284,19 +261,16 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
                     expanded={expanded}
                     setExpanded={setExpanded}
                   />
-
-                  {
-                    <ArgumentsList
-                      list={list}
-                      errors={errors}
-                      hidden={!expanded}
-                      onChange={(name, value) => {
-                        let key = name.toString();
-                        let newValue = { ...values, [key]: value };
-                        setValue(newValue);
-                      }}
-                    />
-                  }
+                  <ArgumentsList
+                    list={list}
+                    errors={errors}
+                    hidden={!expanded}
+                    onChange={(name, value) => {
+                      let key = name.toString();
+                      let newValue = { ...values, [key]: value };
+                      setValue(newValue);
+                    }}
+                  />
                 </>
               )}
               {needSigners && (
@@ -308,29 +282,9 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
               )}
             </>
           )}
-          {!validCode && (
-            <Stack>
-              <Heading>
-                <Title lineColor={theme.colors.error}>Syntax Errors</Title>
-              </Heading>
-              <ErrorsContainer>
-                {syntaxErrors.map((item: CadenceSyntaxError, i) => {
-                  return (
-                    <SingleError
-                      onClick={() => goTo(item.position)}
-                      onMouseOver={() => hover(item.highlight)}
-                      onMouseOut={() => hideDecorations()}
-                    >
-                      <ErrorIndex>
-                        <span>{i + 1}</span>
-                      </ErrorIndex>
-                      <ErrorMessage>{item.message}</ErrorMessage>
-                    </SingleError>
-                  );
-                })}
-              </ErrorsContainer>
-            </Stack>
-          )}
+          {!validCode &&
+            <ErrorsList list={syntaxErrors} goTo={goTo} hover={hover} hideDecorations={hideDecorations}/>
+          }
           <ControlContainer isOk={isOk} progress={progress}>
             <StatusMessage>
               {statusIcon}

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -8,7 +8,9 @@ import {
   ResultType,
   useSetExecutionResultsMutation,
 } from 'api/apollo/generated/graphql';
-import { ControlContainer, HoverPanel, StatusMessage } from './styles';
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api"
+
+import { ControlContainer, HoverPanel, StatusMessage, Heading, Title } from './styles';
 import { Argument } from './types';
 import {
   ActionButton,
@@ -16,13 +18,19 @@ import {
   ArgumentsTitle,
   Signers,
 } from './components';
+import { CadenceSyntaxError, Highlight } from "../../util/language-syntax-errors";
+import { Stack } from "layout/Stack";
 
 
 type ArgumentsProps = {
   type: EntityType;
   list: Argument[];
-  signers: number;
   validCode: boolean;
+  signers: number;
+  syntaxErrors: CadenceSyntaxError[];
+  goTo: (position: monaco.IPosition) => void;
+  hover: (highlight: Highlight) => void;
+  hideDecorations: () => void;
 };
 
 const validateByType = (value: any, type: string) => {
@@ -144,6 +152,7 @@ interface IValue {
 
 const Arguments: React.FC<ArgumentsProps> = (props) => {
   const { type, list, signers, validCode } = props;
+  const { goTo, hover, hideDecorations, syntaxErrors } = props;
   const needSigners = type == EntityType.TransactionTemplate && signers > 0;
   const [selected, updateSelectedAccounts] = useState([]);
   const [expanded, setExpanded] = useState(true);
@@ -272,6 +281,23 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
               }
             </>
           )}
+          {
+            syntaxErrors.length > 0 && (
+              <Stack>
+                <Heading>
+                  <Title>Syntax Errors</Title>
+                </Heading>
+                <Stack>
+                  {syntaxErrors.map((item: CadenceSyntaxError) =>{
+                    return <div
+                      onClick={()=>goTo(item.position)}
+                      onMouseOver={()=>hover(item.highlight)}
+                      onMouseOut={()=>hideDecorations()}>{item.message}</div>
+                  })}
+                </Stack>
+              </Stack>
+            )
+          }
           {needSigners && (
             <Signers
               maxSelection={signers}

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -178,3 +178,15 @@ export const ErrorMessage = styled.p`
   line-height: 1.2;
   word-break: break-word;
 `;
+
+export const SignersError = styled.p`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  margin: 10px 0;
+  color: ${theme.colors.error};
+  svg{
+    margin-right: 0.5em;
+  }
+`;

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -21,7 +21,11 @@ export const Heading = styled.div`
   margin-bottom: 16px;
 `;
 
-export const Title = styled.div`
+interface TitleProps {
+  lineColor?: string
+}
+
+export const Title = styled.div<TitleProps>`
   font-size: 10px;
   font-weight: bold;
   text-transform: uppercase;
@@ -35,7 +39,7 @@ export const Title = styled.div`
     display: block;
     position: absolute;
     left: 0;
-    background: ${theme.colors.primary};
+    background: ${(props: any) => props.lineColor || theme.colors.primary};
     height: 3px;
     width: 1rem;
     bottom: -6px;
@@ -136,4 +140,41 @@ export const StatusMessage = styled.div`
   svg.spin {
     animation: spin 0.5s linear infinite;
   }
+`;
+
+export const ErrorsContainer = styled.div`
+  display: grid;
+  grid-gap: 10px;
+  grid-template-columns: 100%;
+  margin-bottom: 12px;
+`;
+
+export const SingleError = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  box-sizing: border-box;
+  padding: 10px;
+  border-radius: 4px;
+  &:hover{
+    background-color: rgba(244, 57, 64, 0.15);
+  }
+`
+
+export const ErrorIndex = styled.div`
+  width: 20px;
+  height: 20px;
+  background-color: rgba(0,0,0,0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 20px;
+  margin-right: 8px;
+  flex: 0 0 auto;
+`;
+
+export const ErrorMessage = styled.p`
+  font-size: 16px;
+  line-height: 1.2;
+  word-break: break-word;
 `;

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -16,7 +16,7 @@ export const HoverPanel = styled.div<HoverPanelProps>`
 
 export const Heading = styled.div`
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
 `;
@@ -73,13 +73,13 @@ export const Badge = styled.div`
 `;
 
 interface ListProps {
-  hidden: boolean
+  hidden?: boolean
 }
 export const List = styled.div<ListProps>`
   display: ${({ hidden }) => hidden ? 'none' : 'grid'};
   grid-gap: 12px;
   grid-template-columns: 100%;
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 `;
 
 export const SignersContainer = styled.div`
@@ -156,6 +156,7 @@ export const SingleError = styled.div`
   box-sizing: border-box;
   padding: 10px;
   border-radius: 4px;
+  font-size: 14px;
   &:hover{
     background-color: rgba(244, 57, 64, 0.15);
   }
@@ -174,7 +175,6 @@ export const ErrorIndex = styled.div`
 `;
 
 export const ErrorMessage = styled.p`
-  font-size: 16px;
   line-height: 1.2;
   word-break: break-word;
 `;

--- a/src/components/Arguments/types.tsx
+++ b/src/components/Arguments/types.tsx
@@ -1,15 +1,27 @@
+import * as monaco from "monaco-editor";
 import {EntityType} from "providers/Project";
-
-export type Argument = {
-  name: string,
-  type: string
-}
+import {CadenceSyntaxError, Highlight} from "../../util/language-syntax-errors";
 
 export type InteractionButtonProps = {
   onClick: () => void,
   active?: boolean,
   type: EntityType
 }
+
+export type Argument = {
+  name: string,
+  type: string
+}
+
+export type ArgumentsProps = {
+  type: EntityType;
+  list: Argument[];
+  signers: number;
+  syntaxErrors: CadenceSyntaxError[];
+  goTo: (position: monaco.IPosition) => void;
+  hover: (highlight: Highlight) => void;
+  hideDecorations: () => void;
+};
 
 export type ArgumentsTitleProps = {
   type: EntityType,
@@ -23,4 +35,11 @@ export type ArgumentsListProps = {
   hidden: boolean,
   onChange: (name: String, value: any) => void,
   errors: any,
+}
+
+export type ErrorListProps = {
+  list: CadenceSyntaxError[],
+  goTo: (position: monaco.IPosition) => void;
+  hover: (highlight: Highlight) => void;
+  hideDecorations: () => void;
 }

--- a/src/components/Arguments/types.tsx
+++ b/src/components/Arguments/types.tsx
@@ -24,4 +24,3 @@ export type ArgumentsListProps = {
   onChange: (name: String, value: any) => void,
   errors: any,
 }
-

--- a/src/components/CadenceEditor.tsx
+++ b/src/components/CadenceEditor.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled from "@emotion/styled"
+import { keyframes } from "@emotion/core";
 import configureCadence, {CADENCE_LANGUAGE_ID} from "../util/cadence"
 import {CadenceCheckCompleted, CadenceLanguageServer, Callbacks} from "../util/language-server"
 import {createCadenceLanguageClient} from "../util/language-client"
@@ -7,13 +8,19 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api"
 import {EntityType} from "providers/Project";
 import Arguments from "components/Arguments";
 import { Argument } from "components/Arguments/types";
-import {CadenceSyntaxError, formatMarker, goTo} from "../util/language-syntax-errors";
+import {CadenceSyntaxError, formatMarker, goTo, Highlight} from "../util/language-syntax-errors";
 import {
   MonacoLanguageClient,
   ExecuteCommandRequest,
 } from "monaco-languageclient"
 
 const {MonacoServices} = require("monaco-languageclient/lib/monaco-services");
+
+const blink = keyframes`
+  50% {
+    opacity: 0.5;
+  }
+`;
 
 const EditorContainer = styled.div`
   width: 100%;
@@ -39,6 +46,16 @@ const EditorContainer = styled.div`
     bottom: 2vw;
     pointer-events: none;
   }
+
+  .playground-syntax-error-hover{
+    background-color: rgba(238,67, 30, 0.1);
+  }
+  
+  .playground-syntax-error-hover-selection{
+    background-color: rgba(238,67, 30, 0.3);
+    border-radius: 3px;
+    animation: ${blink} 1s ease-in-out infinite;
+  }
 `;
 
 type EditorState = {
@@ -61,7 +78,6 @@ type CadenceEditorProps = {
 
 type CadenceEditorState = {
   args: {[key: string]: Argument[]}
-  valid: {[key: string]: boolean}
   syntaxErrors: {[key: string]: CadenceSyntaxError[]}
 }
 
@@ -89,7 +105,6 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
 
     this.state = {
       args:{},
-      valid: {},
       syntaxErrors: {}
     }
   }
@@ -175,8 +190,6 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
           const params = await this.getParameters()
           this.setExecutionArguments(params)
         }
-        this.setValidState(result.valid)
-
         this.processMarkers()
       })
     })
@@ -197,7 +210,6 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
   }
 
   processMarkers(){
-    // Try to get list of markers
     const model = this.editor.getModel();
     const modelMarkers = monaco.editor.getModelMarkers({resource: model.uri})
     const errors = modelMarkers.map(formatMarker)
@@ -214,15 +226,6 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
     this.setState({
       args: {
         [activeId]: args
-      }
-    })
-  }
-
-  setValidState(valid: boolean){
-    const { activeId } = this.props;
-    this.setState({
-      valid: {
-        [activeId]: valid
       }
     })
   }
@@ -317,12 +320,53 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
       .length
   }
 
-  hover(marker: monaco.editor.IMarker): void {
-    console.log({marker})
+  hover(highlight: Highlight): void {
+    const { startLine, startColumn, endLine, endColumn } = highlight
+    const model = this.editor.getModel()
+
+    const selection = model
+      .getAllDecorations()
+      .find((item: any) => {
+        return (
+          item.range.startLineNumber === startLine &&
+          item.range.startColumn === startColumn
+        )
+      })
+
+    const selectionEndLine = selection ? selection.range.endLineNumber : endLine
+    const selectionEndColumn = selection ? selection.range.endColumn : endColumn
+
+    const highlightLine = [
+      {
+        range: new monaco.Range(startLine, startColumn, endLine, endColumn),
+        options: {
+          isWholeLine: true,
+          className: 'playground-syntax-error-hover',
+        },
+      },
+      {
+        range: new monaco.Range(startLine, startColumn, selectionEndLine, selectionEndColumn),
+        options: {
+          isWholeLine: false,
+          className: 'playground-syntax-error-hover-selection',
+        }
+      }
+    ]
+    this.editor.getModel().deltaDecorations([], highlightLine)
   }
 
   hideDecorations(): void {
-    console.log("Hide decorations")
+    const model = this.editor.getModel()
+    const current = model
+        .getAllDecorations()
+        .filter(item => {
+          return [
+            "playground-syntax-error-hover",
+            "playground-syntax-error-hover-selection"
+          ].includes(item.options.className )
+        }).map(item => item.id)
+
+    model.deltaDecorations(current, [])
   }
 
   render() {
@@ -330,9 +374,8 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
 
     /// Get a list of args from language server
     const { activeId } = this.props;
-    const { args, syntaxErrors, valid } = this.state;
+    const { args, syntaxErrors } = this.state;
     const list = args[activeId] || []
-    const validCode = valid[activeId]
 
     /// Extract number of signers from code
     const signers = this.extractSigners(code);
@@ -343,10 +386,9 @@ class CadenceEditor extends React.Component<CadenceEditorProps, CadenceEditorSta
           type={type}
           list={list}
           signers={signers}
-          validCode={validCode}
           syntaxErrors={errors}
-          hover={this.hover}
-          hideDecorations={this.hideDecorations}
+          hover={(highlight)=> this.hover(highlight)}
+          hideDecorations={()=>this.hideDecorations()}
           goTo={(position: monaco.IPosition)=> goTo(this.editor, position)}
         />
       </EditorContainer>

--- a/src/layout/Main.tsx
+++ b/src/layout/Main.tsx
@@ -5,4 +5,5 @@ export const Main = styled.div`
   display: flex;
   flex-direction: column;
   background: var(--bg);
+  overflow: hidden;
 `;

--- a/src/util/language-syntax-errors.ts
+++ b/src/util/language-syntax-errors.ts
@@ -35,8 +35,8 @@ export const formatMarker = (marker: monaco.editor.IMarker): CadenceSyntaxError 
     highlight: {
       startLine: marker.startLineNumber,
       endLine: marker.endLineNumber,
-      startColumn: marker.startLineNumber,
-      endColumn: marker.startLineNumber
+      startColumn: marker.startColumn,
+      endColumn: marker.endColumn
     }
   }
 };

--- a/src/util/language-syntax-errors.ts
+++ b/src/util/language-syntax-errors.ts
@@ -1,0 +1,63 @@
+// import { FaUnlink, FaRandom } from 'react-icons/fa';
+import { FaExclamationTriangle } from 'react-icons/fa';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+export enum SyntaxError {
+  Generic = 'generic',
+  MissingInitializer = 'init-missing',
+  TypeMissmatch = 'type-missmatch',
+}
+
+export type Highlight = {
+  startLine: number,
+  startColumn: number,
+  endLine: number,
+  endColumn: number
+}
+
+export type CadenceSyntaxError = {
+  message: string,
+  type: string,
+  position: monaco.IPosition,
+  icon: any,
+  highlight: Highlight
+}
+
+export const formatMarker = (marker: monaco.editor.IMarker): CadenceSyntaxError => {
+  return {
+    message: marker.message,
+    type: SyntaxError.Generic,
+    icon: FaExclamationTriangle,
+    position: {
+      lineNumber: marker.startLineNumber,
+      column: marker.startColumn
+    },
+    highlight: {
+      startLine: marker.startLineNumber,
+      endLine: marker.endLineNumber,
+      startColumn: marker.startLineNumber,
+      endColumn: marker.startLineNumber
+    }
+  }
+};
+
+export const getIconByErrorType = (errorType: SyntaxError): any => {
+  switch (errorType) {
+    /*
+    case SyntaxError.TypeMissmatch:
+      return FaRandom;
+    case SyntaxError.Generic:
+      return FaExclamationTriangle;
+    */
+    default:
+      return FaExclamationTriangle;
+  }
+};
+
+export const goTo = (
+  editor: monaco.editor.ICodeEditor,
+  position: monaco.IPosition,
+) => {
+  editor.setPosition(position);
+  editor.focus();
+};


### PR DESCRIPTION
This shall be a FE substitute for #47

While it's possible to go through all the markers by pressing `F8` - good tip to share with community 😉 - I think it's much better to display it as a list, right next to a button, which shall send template to the "chain".