### PR TITLE
Add check for nested items update

### DIFF
--- a/src/components/AccountBottomBar.tsx
+++ b/src/components/AccountBottomBar.tsx
@@ -133,9 +133,10 @@ const AccountState: React.FC<{
       continue;
     }
 
-    const [domain, identifier] = key.split('\u001f');
-
-    if (domain === 'storage') {
+    const tuple = key.split('\u001f')
+    const [domain, identifier] = tuple
+    
+    if (tuple.length === 2 && domain === 'storage') {
       storage[identifier] = parsed[key];
     }
   }

--- a/src/components/AccountBottomBar.tsx
+++ b/src/components/AccountBottomBar.tsx
@@ -135,7 +135,7 @@ const AccountState: React.FC<{
 
     const tuple = key.split('\u001f')
     const [domain, identifier] = tuple
-    
+
     if (tuple.length === 2 && domain === 'storage') {
       storage[identifier] = parsed[key];
     }


### PR DESCRIPTION
If code would contain `load` instruction and then update nested item, then this change would be reflected in updated state, that we are getting back from API.

Let's say we first create and store new `Thing` item inside of the collection. 
Then we send another transaction, which would `load` collection from storage and put new `Thing` with key `test`.

```
storage•collection: {type: "Resource", value: {…}}
storage•collection•container•v•test: null
```
*• represents split character `\u001f`*


👆 In the response that we will get from server `storage•collection` have all the valid information about updated state, but on top of that if will also contain `storage•collection•container•v•test` set to `null`. I suppose, because we destroy old Resource here:

```
    pub fun addThing(key: String, thing: @Thing) {
        let oldThing <- self.container[key] <- thing
        destroy oldThing
    }
```

I added the code, that will skip all the nested changes for now, which fixes the issue with provided example and should work in general, but might also introduce other undiscovered bugs in the future 😅

Closes #54 