### PR TITLE
Fix error styling

### DIFF
--- a/src/components/RenderResponse/Line/index.tsx
+++ b/src/components/RenderResponse/Line/index.tsx
@@ -74,7 +74,7 @@ const Label = styled.strong<{ tag: Tag }>`
     `}
 `;
 
-const Value = styled.span<{ tag: Tag }>`
+const StringValue = styled.pre<{ tag: Tag }>`
   ${p =>
     p.tag === Tag.ERROR &&
     css`
@@ -82,7 +82,7 @@ const Value = styled.span<{ tag: Tag }>`
     `}
 `;
 
-const Pre = styled.pre`
+const ObjectValue = styled.pre`
   border-radius: 3px;
   padding: 13px;
   background: ${theme.colors.muted};
@@ -99,13 +99,11 @@ export const Line: React.FC<LineType> = ({ timestamp, tag, value, label }) => {
       <IoIosArrowForward />
       <Label tag={tag}>{PS1(tag)}</Label>
       <IoIosArrowForward />
-      {typeof value === "string" ? (
-        <>
-          <Value tag={tag}>{value}</Value>
-        </>
-      ) : (
-        <Pre>{JSON.stringify(value, null, 2)}</Pre>
-      )}
+      {
+        typeof value === "string"
+          ? <StringValue tag={tag}>{value}</StringValue>
+          : <ObjectValue>{JSON.stringify(value, null, 2)}</ObjectValue>
+      }
     </Root>
   );
 };


### PR DESCRIPTION
## Description

Make the error message a `<pre>` element, so that whitespace is preserved.

Fixes e.g.

<img width="1184" alt="Screen_Shot_2021-04-13_at_5 34 27_AM" src="https://user-images.githubusercontent.com/51661/114617913-945dd100-9c5d-11eb-86cd-bd7ad3cf507e.png">


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

