### PR TITLE
[WIP RFC] Allow complex arguments in the UI #141

### DIFF
--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -10,18 +10,55 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  UUID: any;
   Version: any;
   Address: any;
-  UUID: any;
   ExecutionResultValue: any;
   RawExecutionResult: any;
 };
 
-export type ProgramError = {
-  __typename?: 'ProgramError';
-  message: Scalars['String'];
-  startPosition?: Maybe<ProgramPosition>;
-  endPosition?: Maybe<ProgramPosition>;
+export type Project = {
+  __typename?: 'Project';
+  id: Scalars['UUID'];
+  publicId: Scalars['UUID'];
+  parentId?: Maybe<Scalars['UUID']>;
+  title: Scalars['String'];
+  seed: Scalars['Int'];
+  version: Scalars['Version'];
+  persist?: Maybe<Scalars['Boolean']>;
+  mutable?: Maybe<Scalars['Boolean']>;
+  accounts?: Maybe<Array<Account>>;
+  transactionTemplates?: Maybe<Array<TransactionTemplate>>;
+  transactionExecutions?: Maybe<Array<TransactionExecution>>;
+  scriptTemplates?: Maybe<Array<ScriptTemplate>>;
+  scriptExecutions?: Maybe<Array<ScriptExecution>>;
+};
+
+export type NewProject = {
+  parentId?: Maybe<Scalars['UUID']>;
+  title: Scalars['String'];
+  seed: Scalars['Int'];
+  accounts?: Maybe<Array<Scalars['String']>>;
+  transactionTemplates?: Maybe<Array<NewProjectTransactionTemplate>>;
+  scriptTemplates?: Maybe<Array<NewProjectScriptTemplate>>;
+};
+
+export type NewProjectTransactionTemplate = {
+  title: Scalars['String'];
+  script: Scalars['String'];
+};
+
+export type NewScriptExecution = {
+  projectId: Scalars['UUID'];
+  script: Scalars['String'];
+  arguments?: Maybe<Array<Scalars['String']>>;
+};
+
+export type ProgramPosition = {
+  __typename?: 'ProgramPosition';
+  offset: Scalars['Int'];
+  line: Scalars['Int'];
+  column: Scalars['Int'];
 };
 
 export type Query = {
@@ -61,16 +98,27 @@ export type QueryTransactionTemplateArgs = {
   projectId: Scalars['UUID'];
 };
 
-export type NewProject = {
-  parentId?: Maybe<Scalars['UUID']>;
+export type TransactionTemplate = {
+  __typename?: 'TransactionTemplate';
+  id: Scalars['UUID'];
+  index: Scalars['Int'];
   title: Scalars['String'];
-  seed: Scalars['Int'];
-  accounts?: Maybe<Array<Scalars['String']>>;
-  transactionTemplates?: Maybe<Array<NewProjectTransactionTemplate>>;
-  scriptTemplates?: Maybe<Array<NewProjectScriptTemplate>>;
+  script: Scalars['String'];
 };
 
-export type NewProjectScriptTemplate = {
+export type TransactionExecution = {
+  __typename?: 'TransactionExecution';
+  id: Scalars['UUID'];
+  script: Scalars['String'];
+  arguments?: Maybe<Array<Scalars['String']>>;
+  signers: Array<Account>;
+  errors?: Maybe<Array<ProgramError>>;
+  events: Array<Maybe<Event>>;
+  logs: Array<Scalars['String']>;
+};
+
+export type NewTransactionTemplate = {
+  projectId: Scalars['UUID'];
   title: Scalars['String'];
   script: Scalars['String'];
 };
@@ -83,11 +131,36 @@ export type UpdateTransactionTemplate = {
   script?: Maybe<Scalars['String']>;
 };
 
-export type NewTransactionExecution = {
-  projectId: Scalars['UUID'];
+
+
+export type ProgramError = {
+  __typename?: 'ProgramError';
+  message: Scalars['String'];
+  startPosition?: Maybe<ProgramPosition>;
+  endPosition?: Maybe<ProgramPosition>;
+};
+
+export type ScriptExecution = {
+  __typename?: 'ScriptExecution';
+  id: Scalars['UUID'];
   script: Scalars['String'];
-  signers?: Maybe<Array<Scalars['Address']>>;
   arguments?: Maybe<Array<Scalars['String']>>;
+  errors?: Maybe<Array<ProgramError>>;
+  value: Scalars['String'];
+  logs: Array<Scalars['String']>;
+};
+
+export type NewProjectScriptTemplate = {
+  title: Scalars['String'];
+  script: Scalars['String'];
+};
+
+export type UpdateScriptTemplate = {
+  id: Scalars['UUID'];
+  title?: Maybe<Scalars['String']>;
+  projectId: Scalars['UUID'];
+  index?: Maybe<Scalars['Int']>;
+  script?: Maybe<Scalars['String']>;
 };
 
 export type Mutation = {
@@ -182,18 +255,10 @@ export type MutationUpdateTransactionTemplateArgs = {
   input: UpdateTransactionTemplate;
 };
 
-export type TransactionTemplate = {
-  __typename?: 'TransactionTemplate';
-  id: Scalars['UUID'];
-  index: Scalars['Int'];
-  title: Scalars['String'];
-  script: Scalars['String'];
-};
-
-export type NewTransactionTemplate = {
-  projectId: Scalars['UUID'];
-  title: Scalars['String'];
-  script: Scalars['String'];
+export type PlaygroundInfo = {
+  __typename?: 'PlaygroundInfo';
+  apiVersion: Scalars['Version'];
+  cadenceVersion: Scalars['Version'];
 };
 
 export type Event = {
@@ -223,7 +288,6 @@ export type UpdateAccount = {
   deployedCode?: Maybe<Scalars['String']>;
 };
 
-
 export type Account = {
   __typename?: 'Account';
   id: Scalars['UUID'];
@@ -234,82 +298,18 @@ export type Account = {
   state: Scalars['String'];
 };
 
-export type NewScriptExecution = {
+
+export type NewTransactionExecution = {
   projectId: Scalars['UUID'];
   script: Scalars['String'];
+  signers?: Maybe<Array<Scalars['Address']>>;
   arguments?: Maybe<Array<Scalars['String']>>;
-};
-
-
-export type ProgramPosition = {
-  __typename?: 'ProgramPosition';
-  offset: Scalars['Int'];
-  line: Scalars['Int'];
-  column: Scalars['Int'];
 };
 
 export type NewScriptTemplate = {
   projectId: Scalars['UUID'];
   title: Scalars['String'];
   script: Scalars['String'];
-};
-
-export type PlaygroundInfo = {
-  __typename?: 'PlaygroundInfo';
-  apiVersion: Scalars['Version'];
-  cadenceVersion: Scalars['Version'];
-};
-
-export type Project = {
-  __typename?: 'Project';
-  id: Scalars['UUID'];
-  publicId: Scalars['UUID'];
-  parentId?: Maybe<Scalars['UUID']>;
-  title: Scalars['String'];
-  seed: Scalars['Int'];
-  version: Scalars['Version'];
-  persist?: Maybe<Scalars['Boolean']>;
-  mutable?: Maybe<Scalars['Boolean']>;
-  accounts?: Maybe<Array<Account>>;
-  transactionTemplates?: Maybe<Array<TransactionTemplate>>;
-  transactionExecutions?: Maybe<Array<TransactionExecution>>;
-  scriptTemplates?: Maybe<Array<ScriptTemplate>>;
-  scriptExecutions?: Maybe<Array<ScriptExecution>>;
-};
-
-export type TransactionExecution = {
-  __typename?: 'TransactionExecution';
-  id: Scalars['UUID'];
-  script: Scalars['String'];
-  arguments?: Maybe<Array<Scalars['String']>>;
-  signers: Array<Account>;
-  errors?: Maybe<Array<ProgramError>>;
-  events: Array<Maybe<Event>>;
-  logs: Array<Scalars['String']>;
-};
-
-export type NewProjectTransactionTemplate = {
-  title: Scalars['String'];
-  script: Scalars['String'];
-};
-
-export type UpdateScriptTemplate = {
-  id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  projectId: Scalars['UUID'];
-  index?: Maybe<Scalars['Int']>;
-  script?: Maybe<Scalars['String']>;
-};
-
-
-export type ScriptExecution = {
-  __typename?: 'ScriptExecution';
-  id: Scalars['UUID'];
-  script: Scalars['String'];
-  arguments?: Maybe<Array<Scalars['String']>>;
-  errors?: Maybe<Array<ProgramError>>;
-  value: Scalars['String'];
-  logs: Array<Scalars['String']>;
 };
 
 

--- a/src/components/Arguments/types.tsx
+++ b/src/components/Arguments/types.tsx
@@ -1,17 +1,22 @@
-import * as monaco from "monaco-editor";
-import {EntityType} from "providers/Project";
-import {CadenceProblem, Highlight, ProblemsList} from "../../util/language-syntax-errors";
+import * as monaco from 'monaco-editor';
+import { EntityType } from 'providers/Project';
+import {
+  CadenceProblem,
+  Highlight,
+  ProblemsList,
+} from '../../util/language-syntax-errors';
+import { MonacoLanguageClient } from 'monaco-languageclient';
 
 export type InteractionButtonProps = {
-  onClick: () => void,
-  active?: boolean,
-  type: EntityType
-}
+  onClick: () => void;
+  active?: boolean;
+  type: EntityType;
+};
 
 export type Argument = {
-  name: string,
-  type: string
-}
+  name: string;
+  type: string;
+};
 
 export type ArgumentsProps = {
   type: EntityType;
@@ -21,36 +26,38 @@ export type ArgumentsProps = {
   goTo: (position: monaco.IPosition) => void;
   hover: (highlight: Highlight) => void;
   hideDecorations: () => void;
+  editor: monaco.editor.IEditor;
+  languageClient: MonacoLanguageClient;
 };
 
 export type ArgumentsTitleProps = {
-  type: EntityType,
-  expanded: boolean,
-  setExpanded: (value: boolean) => void,
-  errors?: number
-}
+  type: EntityType;
+  expanded: boolean;
+  setExpanded: (value: boolean) => void;
+  errors?: number;
+};
 
 export type ArgumentsListProps = {
-  list: Argument[],
-  hidden: boolean,
-  onChange: (name: String, value: any) => void,
-  errors: any,
-}
+  list: Argument[];
+  hidden: boolean;
+  onChange: (name: String, value: any) => void;
+  errors: any;
+};
 
 export type ErrorListProps = {
-  list: CadenceProblem[],
+  list: CadenceProblem[];
   goTo: (position: monaco.IPosition) => void;
   hover: (highlight: Highlight) => void;
   hideDecorations: () => void;
-}
+};
 
 export type HintsProps = {
-  problems: ProblemsList,
-  goTo: (position: monaco.IPosition) => void,
-  hover: (highlight: Highlight) => void,
-  hideDecorations: () => void,
-}
+  problems: ProblemsList;
+  goTo: (position: monaco.IPosition) => void;
+  hover: (highlight: Highlight) => void;
+  hideDecorations: () => void;
+};
 
 export type HintsState = {
-  expanded: boolean
-}
+  expanded: boolean;
+};

--- a/src/components/RenderResponse/Line/index.tsx
+++ b/src/components/RenderResponse/Line/index.tsx
@@ -74,7 +74,7 @@ const Label = styled.strong<{ tag: Tag }>`
     `}
 `;
 
-const Value = styled.span<{ tag: Tag }>`
+const StringValue = styled.pre<{ tag: Tag }>`
   ${p =>
     p.tag === Tag.ERROR &&
     css`
@@ -82,7 +82,7 @@ const Value = styled.span<{ tag: Tag }>`
     `}
 `;
 
-const Pre = styled.pre`
+const ObjectValue = styled.pre`
   border-radius: 3px;
   padding: 13px;
   background: ${theme.colors.muted};
@@ -99,13 +99,11 @@ export const Line: React.FC<LineType> = ({ timestamp, tag, value, label }) => {
       <IoIosArrowForward />
       <Label tag={tag}>{PS1(tag)}</Label>
       <IoIosArrowForward />
-      {typeof value === "string" ? (
-        <>
-          <Value tag={tag}>{value}</Value>
-        </>
-      ) : (
-        <Pre>{JSON.stringify(value, null, 2)}</Pre>
-      )}
+      {
+        typeof value === "string"
+          ? <StringValue tag={tag}>{value}</StringValue>
+          : <ObjectValue>{JSON.stringify(value, null, 2)}</ObjectValue>
+      }
     </Root>
   );
 };


### PR DESCRIPTION
Closes: #141

## Context

Currently the Playground can handle arguments to functions, unless they are complex Cadence types (Struct, Resource, Enum ...etc). 

The following code is where we're determining the Cadence type before sending a properly structured Cadence trasnaction to the API via a GraphQL query: https://github.com/onflow/flow-playground/blob/mackenzie/params-bugfix-%23141/src/components/Arguments/index.tsx#L26

## Description

This PR aims to add support for the missing Cadence types using the built-in Cadence language server to parse parameters for their type, and return the properly formatted Cadence JSON to be sent to the API.

```
const result  = await this.languageClient.sendRequest(ExecuteCommandRequest.type, {
  command: "cadence.server.parseEntryPointArguments",
  arguments: [
        this.editor.getModel().uri.toString(),
        ['{"a": "b"}']
     ]
})
```
This code is how to call the language server from JS to create the valid JSON required by the Playground API / Flow VM.
It will produce valid cadence JSON for the given Cadence code and contract/script parameters by matching on the name.


## Suggested Solution

Replace the existing code for handling arguments input from the UI with this call to the awesome WASM embedded language server, without which this would be impossible! 
