### PR TITLE
Code submission for FLIP fest 'Playground: Fix client-side errors in the playground frontend #58' - Milestone 0.5

### DIFF
--- a/src/components/Examples.tsx
+++ b/src/components/Examples.tsx
@@ -245,7 +245,6 @@ const Examples: React.FC<{
                         href={_example.docsLink}
                         target="_blank"
                         rel="noopener"
-                        key={index}
                         onClick={() => {
                           Mixpanel.track("Redirect to project documentation", {
                             link: _example.docsLink,
@@ -261,7 +260,6 @@ const Examples: React.FC<{
                         href={_example.projectLink}
                         target="_blank"
                         rel="noopener"
-                        key={index}
                         onClick={() => {
                           Mixpanel.track("Open example project", {
                             link: _example.projectLink,

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -291,15 +291,15 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     return null;
   }
 
-  const params = getParams(location.search || '');
-  const { type, id } = params;
+    const params = getParams(location.search || '');
+    const { type, id } = params;
 
   // TODO: check if that project is local
   // TODO: check that active item have the same id
 
   if (type == '' || type === undefined || !scriptTypes.includes(type)) {
     return (
-      <Redirect
+      <Redirect noThrow
         to={`/${project.id}?type=account&id=${project.accounts[0].id}`}
       />
     );
@@ -331,7 +331,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         firstItemId = project.accounts[0].id;
         break;
     }
-    return <Redirect to={`/${project.id}?type=${type}&id=${firstItemId}`} />;
+    return <Redirect noThrow to={`/${project.id}?type=${type}&id=${firstItemId}`} />;
   }
 
   const activeType = type || 'account';
@@ -358,7 +358,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
           index: templateIndex,
         });
         const templateId = project.transactionTemplates[templateIndex].id;
-        return <Redirect to={`/${project.id}?type=tx&id=${templateId}`} />;
+        return <Redirect noThrow to={`/${project.id}?type=tx&id=${templateId}`} />;
       }
       break;
     }
@@ -381,7 +381,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
           index: templateIndex,
         });
         const templateId = project.scriptTemplates[templateIndex].id;
-        return <Redirect to={`/${project.id}?type=script&id=${templateId}`} />;
+        return <Redirect noThrow to={`/${project.id}?type=script&id=${templateId}`} />;
       }
       break;
     }
@@ -405,7 +405,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
           index: templateIndex,
         });
         const templateId = project.accounts[templateIndex].id;
-        return <Redirect to={`/${project.id}?type=account&id=${templateId}`} />;
+        return <Redirect noThrow to={`/${project.id}?type=account&id=${templateId}`} />;
       }
       break;
     }


### PR DESCRIPTION
Closes: #163 #164 #165 #166 

## Description
The Examples.tsx component had unnecessarily been including a 'key' prop in components nested inside of the main component that was being created by the map function. I believe one 'key' prop applied to the main component is sufficient.

The series of Redirects from reach router used in the project provider caused a cascade of errors as described in the four bug issues that I submitted. I'm currently investigating how this can be optimized. For now, the use of 'noThrow' in reach router suppresses the errors in the console. As explained in the reach router docs for the '[Redirect](https://reach.tech/router/api/Redirect)' feature:

"""
Redirect works with componentDidCatch to prevent the tree from rendering and starts over with a new location.

Because React doesn’t swallow the error this might bother you. For example, a redirect will trigger Create React App’s error overlay. In production, everything is fine. If it bothers you, add noThrow and Redirect will do redirect without using componentDidCatch.

If you’re using React < 16 Redirect will not throw at all, regardless of what value you put for this prop.
"""



______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [n/a] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [n/a] Added appropriate labels 

