### PR TITLE
Add limit to project readme

### DIFF
--- a/src/components/Arguments/SingleArgument/styles.tsx
+++ b/src/components/Arguments/SingleArgument/styles.tsx
@@ -12,11 +12,16 @@ export const InputBlock = styled.div<InpubBlockProps>`
   position: relative;
 `
 
-export const Label = styled.p`
+
+interface LabelProps {
+  error?: boolean
+}
+
+export const Label = styled.p<LabelProps>`
   margin: 0;
   font-size: 14px;
   margin-bottom: 5px;
-  color: #000;
+  color: ${({error})=> error ? "#EE431E" : "#000"};
 `;
 
 export const Type = styled.span`

--- a/src/components/MdeEditor.tsx
+++ b/src/components/MdeEditor.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 import SimpleMDE from "react-simplemde-editor";
-import { PLACEHOLDER_README } from "providers/Project/projectDefault";
 import "easymde/dist/easymde.min.css";
 import "unreset-css/dist/unreset.min.css"; // restore browser default element styles
-
+import "../styles/markdown.css"
 
 export const MdeEditor: React.FC<{
   value: string;
   onChange: (v: string) => void;
-}> = ({ value, onChange }) => {
+  overflow: boolean
+}> = ({ value, onChange, overflow }) => {
+
+  const className = overflow ? "unreset ease-md-red-border" : "unreset"
 
   return (
     <SimpleMDE
-      className="unreset"
+      className={className}
       value={value}
       onChange={v => onChange(v)}
-      options={{
-        placeholder: PLACEHOLDER_README
-      }}
     />
   )
 }

--- a/src/containers/Editor/components.tsx
+++ b/src/containers/Editor/components.tsx
@@ -213,6 +213,12 @@ const compareContracts = (prev: Account[], current: Account[]) => {
 
 let monacoServicesInstalled = false;
 
+const MAX_DESCRIPTION_SIZE = Math.pow(1024, 2) // 1mb of storage can be saved into readme field
+const calculateSize = (readme: string) => {
+  const { size } = new Blob([readme])
+  return size >= MAX_DESCRIPTION_SIZE
+}
+
 const EditorContainer: React.FC<EditorContainerProps> = ({
   isLoading,
   project,
@@ -230,6 +236,8 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
   const [activeId, setActiveId] = useState(null);
 
   const projectAccess = useProject()
+
+  const [descriptionOverflow, setDescriptionOverflow] = useState(false)
 
   useEffect(() => {
     if (isLoading) {
@@ -350,7 +358,7 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
   };
 
   const isReadmeEditor = active.type === 4;
-
+  console.log({descriptionOverflow})
   return (
     <MainRoot>
       <EditorRoot>
@@ -399,8 +407,12 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
               <MdeEditor
                 value={readme}
                 onChange={(readme: string) => {
-                  setReadme(readme);
-                  updateProject(title, description, readme);
+                  const overflow = calculateSize(readme)
+                  setDescriptionOverflow(overflow)
+                  if(!overflow){
+                    setReadme(readme);
+                    updateProject(title, description, readme);
+                  }
                 }}
               />
             </>

--- a/src/containers/Editor/components.tsx
+++ b/src/containers/Editor/components.tsx
@@ -213,7 +213,7 @@ const compareContracts = (prev: Account[], current: Account[]) => {
 
 let monacoServicesInstalled = false;
 
-const MAX_DESCRIPTION_SIZE = Math.pow(3, 2) // 1mb of storage can be saved into readme field
+const MAX_DESCRIPTION_SIZE = Math.pow(1024, 2) // 1mb of storage can be saved into readme field
 const calculateSize = (readme: string) => {
   const { size } = new Blob([readme])
   return size >= MAX_DESCRIPTION_SIZE

--- a/src/containers/Editor/components.tsx
+++ b/src/containers/Editor/components.tsx
@@ -213,7 +213,7 @@ const compareContracts = (prev: Account[], current: Account[]) => {
 
 let monacoServicesInstalled = false;
 
-const MAX_DESCRIPTION_SIZE = Math.pow(1024, 2) // 1mb of storage can be saved into readme field
+const MAX_DESCRIPTION_SIZE = Math.pow(3, 2) // 1mb of storage can be saved into readme field
 const calculateSize = (readme: string) => {
   const { size } = new Blob([readme])
   return size >= MAX_DESCRIPTION_SIZE
@@ -237,7 +237,7 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
 
   const projectAccess = useProject()
 
-  const [descriptionOverflow, setDescriptionOverflow] = useState(false)
+  const [descriptionOverflow, setDescriptionOverflow] = useState(calculateSize(project.readme))
 
   useEffect(() => {
     if (isLoading) {
@@ -358,7 +358,11 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
   };
 
   const isReadmeEditor = active.type === 4;
-  console.log({descriptionOverflow})
+  const readmeLabel =  `README.md${descriptionOverflow
+          ? " - Content can't be more than 1Mb in size"
+          : ""
+  }`
+
   return (
     <MainRoot>
       <EditorRoot>
@@ -403,17 +407,18 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
                   }}
                 />
               </InputBlock>
-              <Label>README.md</Label>
+              <Label error={descriptionOverflow}>{readmeLabel} </Label>
               <MdeEditor
                 value={readme}
                 onChange={(readme: string) => {
                   const overflow = calculateSize(readme)
                   setDescriptionOverflow(overflow)
+                  setReadme(readme);
                   if(!overflow){
-                    setReadme(readme);
                     updateProject(title, description, readme);
                   }
                 }}
+                overflow={descriptionOverflow}
               />
             </>
           )}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,0 +1,5 @@
+.ease-md-red-border .editor-toolbar,
+.ease-md-red-border .CodeMirror-wrap{
+    border-color: #EE431E;
+    transition: border 0.5s ease-in-out;
+}

--- a/src/wasm_exec.js
+++ b/src/wasm_exec.js
@@ -247,7 +247,7 @@
 					},
 
 					// func walltime() (sec int64, nsec int32)
-					"runtime.walltime": (sp) => {
+					"runtime.walltime1": (sp) => {
 						sp >>>= 0;
 						const msec = (new Date).getTime();
 						setInt64(sp + 8, msec / 1000);


### PR DESCRIPTION
Closes: #230 
Closes: #218 

## Testing Plan
- [ ] Set smaller limit on `MAX_DESCRIPTION_SIZE` constant in `src/containers/Editor/components.tsx` file. When you put more content that you allowed you should see changes in the input block. Changes won't be saved until the content is smaller than `MAX_DESCRIPTION_SIZE`
- [ ] Try to input anything in readme field. Should keep focus on the input block.
- [ ] Try to delete all the content. Placeholder would be blank. There is no immediate solution to placeholder problem :shrug: 

