### PR TITLE
Revert wasm_exec file

### DIFF
--- a/src/wasm_exec.js
+++ b/src/wasm_exec.js
@@ -247,7 +247,7 @@
 					},
 
 					// func walltime() (sec int64, nsec int32)
-					"runtime.walltime1": (sp) => {
+					"runtime.walltime": (sp) => {
 						sp >>>= 0;
 						const msec = (new Date).getTime();
 						setInt64(sp + 8, msec / 1000);


### PR DESCRIPTION
There is definitely some issue with `runtime.walltime` in `wasm_exec.js` file, which makes it work differently depending on OS.

This one is reverted version, which should enable language server to be a bit more stable.