### PR TITLE
Replace Travis CI job with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
-name: Tests
+name: Continuous Integration
 
 on:
   push:
 
 jobs:
   test:
+    name: "Tests"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
+name: Tests
+
 on:
   push:
 
 jobs:
   test:
-    name: "Tests"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - 13
-script:
-  - make ci


### PR DESCRIPTION
## Description

When updating the deployment pipeline, I noticed that we are still using Travis CI on this repository. I moved the CI checks to GitHub Actions to be more consistent with our other repositories.

