### PR TITLE
Add confirm prompt to control panel

### DIFF
--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -105,15 +105,18 @@ export const SignersContainer = styled.div`
 interface ControlContainerProps {
   isOk: boolean;
   progress: boolean;
+  showPrompt?: boolean;
 }
 export const ControlContainer = styled.div<ControlContainerProps>`
-  display: flex;
+  display: ${({ showPrompt }) => showPrompt ? 'block' : 'flex'};
   align-items: center;
   justify-content: space-between;
-  color: ${({ isOk, progress }) => {
+  color: ${({ isOk, progress, showPrompt }) => {
     switch (true) {
       case progress:
         return '#a2a2a2';
+      case isOk && showPrompt:
+        return theme.colors.error;
       case isOk:
         return '#2bb169';
       default:

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -2,11 +2,11 @@ import styled from 'styled-components';
 import theme from '../../theme';
 
 interface HoverPanelProps {
-  width?: string;
+  minWidth?: string;
 }
 
 export const HoverPanel = styled.div<HoverPanelProps>`
-  min-width: 300px;
+  min-width: ${({minWidth}) => minWidth};
   max-width: 500px;
   padding: 20px;
   border-radius: 4px;
@@ -109,6 +109,7 @@ interface ControlContainerProps {
 }
 export const ControlContainer = styled.div<ControlContainerProps>`
   display: ${({ showPrompt }) => showPrompt ? 'block' : 'flex'};
+  max-width: ${({ showPrompt }) => showPrompt ? 'min-content' : 'none'};
   align-items: center;
   justify-content: space-between;
   color: ${({ isOk, progress, showPrompt }) => {

--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -2,6 +2,7 @@ import React  from 'react';
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 import theme from '../../../theme';
+import Button from 'components/Button';
 
 export const MotionBox = (props: any) => {
   const { children, dragConstraints } = props;
@@ -230,3 +231,7 @@ export const SignersError = styled.p`
     margin-right: 0.5em;
   }
 `;
+
+export const Confirm = styled(Button)`
+  margin-right: 0.5rem;
+`

--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -251,3 +251,29 @@ export const Cancel = styled(Button)`
     background-color: #dedede;
   }
 `
+
+export const PromptActionsContainer = styled.div`
+  padding-top: 1rem;
+  display: flex;
+  justify-content: end;
+`;
+
+interface StatusIconProps {
+  isOk: boolean;
+  progress: boolean;
+  showPrompt: boolean;
+}
+export const StatusIcon = styled.div<StatusIconProps>`
+  color: ${({ isOk, progress, showPrompt }) => {
+    switch (true) {
+      case progress:
+        return '#a2a2a2';
+      case isOk && showPrompt:
+        return theme.colors.warning;
+      case isOk:
+        return '#2bb169';
+      default:
+        return '#EE431E';
+    }
+  }};
+`;

--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -233,5 +233,21 @@ export const SignersError = styled.p`
 `;
 
 export const Confirm = styled(Button)`
+  background-color: ${theme.colors.error};
+  color: #fff;
   margin-right: 0.5rem;
+
+  &:active {
+    background-color: #cf3529;
+  }
+`
+
+export const Cancel = styled(Button)`
+  background-color: ${theme.colors.background};
+  color: ${theme.colors.text};
+  border: 1px solid ${theme.colors.greyBorder};
+
+  &:active {
+    background-color: #dedede;
+  }
 `

--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -255,7 +255,7 @@ export const Cancel = styled(Button)`
 export const PromptActionsContainer = styled.div`
   padding-top: 1rem;
   display: flex;
-  justify-content: end;
+  justify-content: center;
 `;
 
 interface StatusIconProps {

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -37,7 +37,7 @@ import {
 // Component Scoped Files
 import { getLabel, validateByType, useTemplateType } from './utils';
 import { ControlPanelProps, IValue } from './types';
-import { MotionBox, Confirm, Cancel } from './components';
+import { MotionBox, Confirm, Cancel, PromptActionsContainer, StatusIcon } from './components';
 
 // Other
 import {
@@ -48,7 +48,6 @@ import {
   Hints,
   Signers,
 } from '../../Arguments/components';
-import theme from '../../../theme';
 import {
   ControlContainer,
   HoverPanel,
@@ -356,7 +355,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   switch (true) {
     case isOk && showPrompt:
       statusIcon = (
-        <FaExclamationTriangle style={{ color: theme.colors.warning }} />
+        <FaExclamationTriangle />
       );
       statusMessage =
         'Redeploying will clear the state of all accounts. Proceed?';
@@ -433,16 +432,18 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
           <ErrorsList list={problems.error} actions={actions} />
           <Hints problems={problems} actions={actions} />
 
-          <ControlContainer isOk={isOk} progress={progress}>
+          <ControlContainer isOk={isOk} progress={progress} showPrompt={showPrompt}>
             <StatusMessage>
-              {statusIcon}
+              <StatusIcon isOk={isOk} progress={progress} showPrompt={showPrompt}>
+                {statusIcon}
+              </StatusIcon>
               <p>{statusMessage}</p>
             </StatusMessage>
             {showPrompt ? (
-              <>
+              <PromptActionsContainer>
                 <Confirm onClick={send}>Confirm</Confirm>
                 <Cancel onClick={() => setShowPrompt(false)}>Cancel</Cancel>
-              </>
+              </PromptActionsContainer>
             ) : (
               <ActionButton active={isOk} type={type} onClick={send} />
             )}

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -1,6 +1,11 @@
 // External Modules
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { FaExclamationTriangle, FaRegCheckCircle, FaRegTimesCircle, FaSpinner } from 'react-icons/fa';
+import {
+  FaExclamationTriangle,
+  FaRegCheckCircle,
+  FaRegTimesCircle,
+  FaSpinner,
+} from 'react-icons/fa';
 import { ExecuteCommandRequest } from 'monaco-languageclient';
 import {
   IPosition,
@@ -32,7 +37,7 @@ import {
 // Component Scoped Files
 import { getLabel, validateByType, useTemplateType } from './utils';
 import { ControlPanelProps, IValue } from './types';
-import { MotionBox, Confirm } from './components';
+import { MotionBox, Confirm, Cancel } from './components';
 
 // Other
 import {
@@ -43,14 +48,13 @@ import {
   Hints,
   Signers,
 } from '../../Arguments/components';
-
+import theme from '../../../theme';
 import {
   ControlContainer,
   HoverPanel,
   Hidable,
   StatusMessage,
 } from '../../Arguments/styles';
-import Button from 'components/Button';
 
 const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   // We should not render this component if editor is non-existent
@@ -351,17 +355,20 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   let statusMessage;
   switch (true) {
     case isOk && showPrompt:
-      statusIcon = <FaExclamationTriangle />
-      statusMessage = 'Redeploying will clear the state of all accounts. Proceed?';
+      statusIcon = (
+        <FaExclamationTriangle style={{ color: theme.colors.warning }} />
+      );
+      statusMessage =
+        'Redeploying will clear the state of all accounts. Proceed?';
       break;
     case isOk:
-      statusIcon = <FaRegCheckCircle />
+      statusIcon = <FaRegCheckCircle />;
       statusMessage = 'Ready';
       break;
     default:
-      statusIcon = <FaRegTimesCircle />
+      statusIcon = <FaRegTimesCircle />;
       statusMessage = 'Fix errors';
-      break
+      break;
   }
 
   const progress = isSavingCode || processingStatus;
@@ -434,7 +441,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             {showPrompt ? (
               <>
                 <Confirm onClick={send}>Confirm</Confirm>
-                <Button onClick={() => setShowPrompt(false)}>Cancel</Button>
+                <Cancel onClick={() => setShowPrompt(false)}>Cancel</Cancel>
               </>
             ) : (
               <ActionButton active={isOk} type={type} onClick={send} />

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -398,7 +398,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     <>
       <div ref={constraintsRef} className="constraints" />
       <MotionBox dragConstraints={constraintsRef}>
-        <HoverPanel>
+        <HoverPanel minWidth={showPrompt ? 'min-content' : '300px'}>
           <Hidable hidden={!validCode}>
             {list.length > 0 && (
               <>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,6 +12,7 @@ export default {
     border: "rgb(240, 240, 240)",
     borderDark: "rgb(222, 222, 222)",
     shadowColor: "rgb(222, 222, 222)",
+    warning: "#ffcc00",
     error: "#f44336",
     blue: "#0000ff",
     heading: "#919191",


### PR DESCRIPTION
Closes: #38

## Description

Add prompt to ControlPanel component warning user that redeploying account will reset account states instead of using the native browser `confirm` method

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

