### PR TITLE
cadence version warning

### DIFF
--- a/src/components/CadenceVersion.tsx
+++ b/src/components/CadenceVersion.tsx
@@ -2,10 +2,13 @@ import React, { useState, useEffect, useContext } from 'react';
 import { CadenceCheckerContext } from 'providers/CadenceChecker';
 import styled from 'styled-components';
 
+import theme from '../theme';
+
 export const StatusContainer = styled.div`
   display: grid;
   justify-content: flex-end;
   grid-gap: 10px;
+  position: relative;
   grid-template-columns: repeat(2, auto);
   align-items: center;
 `;
@@ -16,7 +19,7 @@ export const DotBox = styled.div`
   align-items: baseline;
   flex-direction: row;
   gap: 3px;
-`
+`;
 
 interface DotType {
   active: string;
@@ -30,6 +33,59 @@ export const Dot = styled.div<DotType>`
   background-color: ${({ active = false }) => {
     return active === 'OFF' ? '#ee431e' : '#00ff76';
   }};
+`;
+
+const CadenceVersionMessage = styled.div`
+  position: absolute;
+  z-index: 13;
+  line-height: 13px;
+  top: 100%;
+  background: white;
+  padding: 1rem;
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  border-radius: 4px;
+  margin-top: 0.5rem;
+  display: none;
+`;
+
+const TwoToneWarningIcon = () => (
+  <svg
+    stroke="currentColor"
+    fill="currentColor"
+    stroke-width="0"
+    viewBox="0 0 1024 1024"
+    width="1.125rem"
+    height="1.125rem"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M955.7 856l-416-720c-6.2-10.7-16.9-16-27.7-16s-21.6 5.3-27.7 16l-416 720C56 877.4 71.4 904 96 904h832c24.6 0 40-26.6 27.7-48zm-783.5-27.9L512 239.9l339.8 588.2H172.2z"
+      fill={theme.colors.warning}
+    ></path>
+    <path
+      d="M172.2 828.1h679.6L512 239.9 172.2 828.1zM560 720a48.01 48.01 0 0 1-96 0 48.01 48.01 0 0 1 96 0zm-16-304v184c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V416c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8z"
+      fill={theme.colors.warning}
+    ></path>
+    <path
+      d="M464 720a48 48 0 1 0 96 0 48 48 0 1 0-96 0zm16-304v184c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V416c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8z"
+      fill="black"
+    ></path>
+  </svg>
+);
+
+const WarningIcon = styled(TwoToneWarningIcon)`
+  position: relative;
+  font-size: 20rem;
+  margin-left: 0.5rem;
+`;
+
+const CadenceVersion = styled.div`
+  display: flex;
+  cursor: default;
+  align-items: center;
+  &:hover + div {
+    display: block;
+  }
 `;
 
 const API = process.env.PLAYGROUND_API;
@@ -59,7 +115,14 @@ export const Version = () => {
         <Dot active={lsStatus} title={`Language Server is ${lsStatus}`} />
         <Dot active={lcStatus} title={`Language Client is ${lsStatus}`} />
       </DotBox>
-      <span>Cadence: {version}</span>
+      <CadenceVersion>
+        <span>Cadence: {version}</span>
+        <WarningIcon />
+      </CadenceVersion>
+      <CadenceVersionMessage>
+        The playground is currently running an older version of Cadence and will
+        be updated shortly
+      </CadenceVersionMessage>
     </StatusContainer>
   );
 };


### PR DESCRIPTION
## Description

Adds a warning icon and message when the cadence version is hovered on by the mouse
![Screen Shot 2022-06-08 at 2 04 23 PM](https://user-images.githubusercontent.com/46465568/172707014-ec45689b-c464-4f97-af03-1297172ad5ef.png)
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 



