### PR TITLE
Amit/bug fixes

### DIFF
--- a/src/components/CadenceEditor/index.tsx
+++ b/src/components/CadenceEditor/index.tsx
@@ -144,7 +144,7 @@ const CadenceEditor = (props: any) => {
     if (editor) {
       setupEditor();
     }
-  }, [editor, project.active.index, project.active.type]);
+  }, [editor, project.active.index, project.active.type, project.project.accounts]);
 
   // "initEditor" will create new instance of Monaco Editor and set it up
   const initEditor = async () => {

--- a/src/hooks/useLanguageServer.ts
+++ b/src/hooks/useLanguageServer.ts
@@ -1,10 +1,9 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { CadenceLanguageServer, Callbacks } from 'util/language-server';
 import { MonacoServices } from 'monaco-languageclient/lib/monaco-services';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { createCadenceLanguageClient } from 'util/language-client';
 import { useProject } from 'providers/Project/projectHooks';
-import debounce from "util/debounce";
 
 let monacoServicesInstalled = false;
 
@@ -88,20 +87,11 @@ export default function useLanguageServer() {
     });
   };
 
-  const debouncedServerRestart = useMemo(
-      () => debounce(restartServer, 150),
-      [languageServer]
-  )
-
   useEffect(() => {
     if (languageServer) {
       languageServer.updateCodeGetter(getCode);
     }
   }, [project.project.accounts]);
-
-  // TODO: Disable this, once the cadence language server package is updated
-  useEffect(debouncedServerRestart, [project.project.accounts, project.active]);
-
 
   useEffect(() => {
     // The Monaco Language Client services have to be installed globally, once.
@@ -117,15 +107,11 @@ export default function useLanguageServer() {
     restartServer();
   }, []);
 
-
-
   useEffect(() => {
     if (!languageClient) {
       launchLanguageClient(callbacks, languageServer, setLanguageClient).then();
     }
   }, [languageServer]);
-
-
 
   return {
     languageClient,

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useState, useMemo} from 'react';
+import React, {createContext, useState} from 'react';
 import { useApolloClient, useQuery } from '@apollo/react-hooks';
 import { navigate, useLocation, Redirect } from '@reach/router';
 import ProjectMutator from './projectMutator';
@@ -349,10 +349,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     }
   };
 
-  const activeEditor = useMemo(
-      getActiveEditor,
-      [active.type, active.index, project]
-  )
+  const activeEditor = getActiveEditor()
 
   const location = useLocation();
   if (isLoading) return null;


### PR DESCRIPTION
## Description

This PR addresses the following bugs in playground:
* Changing of code not reflecting when resending a transaction or script
* Changing of transaction parameters not reflecting when resending a transaction or script

Some of these fixes are done by reverting previously made changes in commits from a few months ago which I noticed were causing these bugs to come up on the production site. Specifically those changes that were reverted were put in to add some memoization for performance reasons. I don't have much context on how important those changes were, so would greatly appreciate some extra context around that.

Manually tested across many example scripts + transactions.

Reproduction steps which you can run on play.onflow.org and on this local version to see the difference in functionality:
1. Open Playground on fresh incognito browser.
2. Head to default created transaction.
3. Remove references to helloworld
4. Modify parameter like so: transaction(a: Int) {
5. Add log in prepare like so: log(a)
6. Fill in int param, and click send.
7. It often fails first time due to a different bug which I have not fixed (`Error: GraphQL error: addresses must be 8 bytes`). If so, just modify the code again (space and backspace)
8. Add more params and logs, and verify that clicking send works as expected for each change
