### PR TITLE
Disable save and deploy buttons while loading

### DIFF
--- a/src/containers/Editor/layout.tsx
+++ b/src/containers/Editor/layout.tsx
@@ -48,7 +48,7 @@ const EditorLayout: React.FC = () => {
   const [projectIsPlayground, setIsPlayground] = useState(false);
   const {
     project,
-    mutator,
+    updateProject,
     isSavingCode,
     isLoading,
     active,
@@ -229,8 +229,7 @@ const EditorLayout: React.FC = () => {
                   saveText={project.parentId ? 'Fork' : 'Save'}
                   showShare={project.persist}
                   onSave={() =>
-                    mutator.saveProject(
-                      !!project.parentId,
+                    updateProject(
                       project.title,
                       project.description,
                       project.readme,

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -153,6 +153,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
 
   const updateAccountDeployedCode: any = async () => {
     clearTimeout(timeout);
+    setIsSaving(true);
     const res = await mutator.updateAccountDeployedCode(
       project.accounts[active.index],
       active.index,
@@ -164,7 +165,6 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     const signer = [acctHex];
     setLastSigners(signer);
 
-    setIsSaving(true);
     timeout = setTimeout(() => {
       setIsSaving(false);
     }, 1000);


### PR DESCRIPTION
- Saving state was being updated after the transaction completed when deploying a contract
- Save button was not using the updateProject function, which sets the saving state

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

