### PR TITLE
Fix transaction/script rename bug

### DIFF
--- a/src/components/MenuList.tsx
+++ b/src/components/MenuList.tsx
@@ -54,10 +54,6 @@ const MenuList: React.FC<MenuListProps> = ({
   };
 
   useEffect(() => {
-    setEditing([]);
-  }, [items, active]);
-
-  useEffect(() => {
     if (enterPressed || escapePressed) {
       setEditing([]);
       isEditing.current?.blur();


### PR DESCRIPTION
setEditing was being triggered twice. The useEffect was unnecessary, onBlur already handles saving the changes

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

