### PR TITLE
Serialize project queries/mutations to fix race conditions

### DIFF
--- a/src/components/RenderResponse/index.tsx
+++ b/src/components/RenderResponse/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import { useQuery } from '@apollo/react-hooks';
-import { GET_CACHED_EXECUTION_RESULTS } from 'api/apollo/queries';
 import { ResultType } from 'api/apollo/generated/graphql';
+import { GET_CACHED_EXECUTION_RESULTS } from 'api/apollo/queries';
+import React from 'react';
 import { Line as LineType } from 'util/normalize-interaction-response';
 
-import { Line } from 'components/RenderResponse/Line';
 import styled from '@emotion/styled';
+import { Line } from 'components/RenderResponse/Line';
+import { PROJECT_SERIALIZATION_KEY } from 'providers/Project/projectMutator';
 
 const Root = styled.div<{ resultType: ResultType }>`
   counter-reset: lines;
@@ -17,7 +18,11 @@ const Root = styled.div<{ resultType: ResultType }>`
 export const RenderResponse: React.FC<{
   resultType: ResultType.Transaction | ResultType.Script | ResultType.Contract;
 }> = ({ resultType }) => {
-  const { data, error, loading } = useQuery(GET_CACHED_EXECUTION_RESULTS);
+  const { data, error, loading } = useQuery(GET_CACHED_EXECUTION_RESULTS, {
+    context: {
+      serializationKey: PROJECT_SERIALIZATION_KEY,
+    },
+  });
   return (
     <Root resultType={resultType}>
       {!loading &&

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -2,7 +2,7 @@ import { useApolloClient, useQuery } from '@apollo/react-hooks';
 import { navigate, Redirect, useLocation } from '@reach/router';
 import React, { createContext, useEffect, useRef, useState } from 'react';
 import useGetProject from './projectHooks';
-import ProjectMutator from './projectMutator';
+import ProjectMutator, { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 
 import { Account, Project } from 'api/apollo/generated/graphql';
 import { GET_ACTIVE_PROJECT } from 'api/apollo/queries';
@@ -85,7 +85,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
 
   const {
     data: { activeProject, activeProjectId },
-  } = useQuery(GET_ACTIVE_PROJECT);
+  } = useQuery(GET_ACTIVE_PROJECT, {
+    context: {
+      serializationKey: PROJECT_SERIALIZATION_KEY,
+    },
+  });
 
   const projectId = activeProjectId || urlProjectId;
 

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -1,11 +1,12 @@
-import { useContext } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+import { useContext } from 'react';
 
-import { GET_PROJECT, GET_LOCAL_PROJECT } from 'api/apollo/queries';
+import { GET_LOCAL_PROJECT, GET_PROJECT } from 'api/apollo/queries';
 
 import { Project } from 'api/apollo/generated/graphql';
 import { ProjectContext, ProjectContextValue } from './index';
 import { createDefaultProject, createLocalProject } from './projectDefault';
+import { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 
 function writeDefaultProject(client: any) {
   const defaultProject = createDefaultProject();
@@ -62,6 +63,9 @@ export default function useGetProject(
     variables: { projectId: projectId },
     // skip remote query if this is a new project
     skip: isNewProject,
+    context: {
+      serializationKey: PROJECT_SERIALIZATION_KEY,
+    },
   });
 
   if (isNewProject) {

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -26,6 +26,9 @@ import {
   unregisterOnCloseSaveMessage,
 } from 'util/onclose';
 
+// TODO: Switch to directives for serialization keys after upgrading to the newest Apollo/apollo-link-serialize
+export const PROJECT_SERIALIZATION_KEY = 'PROJECT_SERIALIZATION_KEY';
+
 export default class ProjectMutator {
   client: ApolloClient<object>;
   projectId: string | null = null;
@@ -82,6 +85,9 @@ export default class ProjectMutator {
         transactionTemplates: transactionTemplates,
         scriptTemplates: scriptTemplates,
       },
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     const project = data.project;
@@ -92,9 +98,10 @@ export default class ProjectMutator {
     await this.client.mutate({
       mutation: SET_ACTIVE_PROJECT,
       variables: {
-        id: this.projectId,
+        id: project.id,
       },
     });
+
     Mixpanel.people.set({
       projectId: project.id,
     });
@@ -135,7 +142,7 @@ export default class ProjectMutator {
       },
       context: {
         debounceKey: key,
-        serializationKey: key,
+        serializationKey: PROJECT_SERIALIZATION_KEY,
       },
     });
 
@@ -173,7 +180,7 @@ export default class ProjectMutator {
       },
       context: {
         debounceKey: key,
-        serializationKey: key,
+        serializationKey: PROJECT_SERIALIZATION_KEY,
       },
       fetchPolicy: 'no-cache',
     });
@@ -198,6 +205,9 @@ export default class ProjectMutator {
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
       awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     Mixpanel.track('Contract deployed', {
@@ -205,6 +215,7 @@ export default class ProjectMutator {
       accountId: account.id,
       code: account.draftCode,
     });
+
     return res;
   }
 
@@ -238,7 +249,7 @@ export default class ProjectMutator {
       },
       context: {
         debounceKey: key,
-        serializationKey: key,
+        serializationKey: PROJECT_SERIALIZATION_KEY,
       },
       fetchPolicy: 'no-cache',
     });
@@ -268,6 +279,10 @@ export default class ProjectMutator {
       refetchQueries: [
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
+      awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
     Mixpanel.track('Transaction template executed', {
       projectId: this.projectId,
@@ -293,6 +308,9 @@ export default class ProjectMutator {
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
       awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     Mixpanel.track('Transaction template created', {
@@ -333,7 +351,7 @@ export default class ProjectMutator {
       },
       context: {
         debounceKey: key,
-        serializationKey: key,
+        serializationKey: PROJECT_SERIALIZATION_KEY,
       },
       fetchPolicy: 'no-cache',
     });
@@ -341,7 +359,7 @@ export default class ProjectMutator {
 
   async deleteTransactionTemplate(templateId: string) {
     if (this.isLocal) {
-      this.createProject();
+      await this.createProject();
     }
 
     const res = await this.client.mutate({
@@ -353,6 +371,10 @@ export default class ProjectMutator {
       refetchQueries: [
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
+      awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     return res;
@@ -372,6 +394,10 @@ export default class ProjectMutator {
       refetchQueries: [
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
+      awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     return res;
@@ -389,11 +415,15 @@ export default class ProjectMutator {
         script,
         arguments: args,
       },
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
     Mixpanel.track('Script template executed', {
       projectId: this.projectId,
       script,
     });
+
     return res;
   }
 
@@ -413,6 +443,9 @@ export default class ProjectMutator {
         { query: GET_PROJECT, variables: { projectId: this.projectId } },
       ],
       awaitRefetchQueries: true,
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
     });
 
     Mixpanel.track('Script template created', {


### PR DESCRIPTION
https://github.com/onflow/flow-playground/issues/342#issuecomment-1259595463

Problem:
- Creating a new project triggers a mutation that sets the activeProjectId
- The new activeProjectId triggers a query outside the projectMutator, which can't be awaited

Solution:
- Serialize all project queries queries and mutations to avoid race conditions

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

