### PR TITLE
Update project cache without triggering new project queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "flow-playground",
       "dependencies": {
-        "@apollo/react-hooks": "^3.1.3",
+        "@apollo/react-hooks": "^3.1.5",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.10.4",
         "@onflow/cadence-language-server": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:check": "npm run format:check:app && npm run lint && npm run types"
   },
   "dependencies": {
-    "@apollo/react-hooks": "^3.1.3",
+    "@apollo/react-hooks": "^3.1.5",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.10.4",
     "@onflow/cadence-language-server": "^0.26.1",

--- a/src/api/apollo/mutations.ts
+++ b/src/api/apollo/mutations.ts
@@ -24,14 +24,30 @@ export const CREATE_PROJECT = gql`
       }
     ) {
       id
-      parentId
+      persist
       mutable
+      parentId
+      seed
+      title
+      description
+      readme
       accounts {
         id
         address
         draftCode
         deployedCode
+        deployedContracts
         state
+      }
+      transactionTemplates {
+        id
+        script
+        title
+      }
+      scriptTemplates {
+        id
+        script
+        title
       }
     }
   }

--- a/src/providers/Project/projectDefault.ts
+++ b/src/providers/Project/projectDefault.ts
@@ -1,8 +1,8 @@
 import {
-  Project,
   Account,
-  TransactionTemplate,
+  Project,
   ScriptTemplate,
+  TransactionTemplate,
 } from 'api/apollo/generated/graphql';
 import { strToSeed, uuid } from 'util/rng';
 import { LOCAL_PROJECT_ID } from 'util/url';
@@ -110,6 +110,8 @@ const DEFAULT_ACCOUNT_5 = `access(all) contract HelloWorld {
 }
 `;
 
+export const DEFAULT_ACCOUNT_STATE = '{}';
+
 const DEFAULT_ACCOUNTS = [
   DEFAULT_ACCOUNT_1,
   DEFAULT_ACCOUNT_2,
@@ -184,7 +186,7 @@ export function createLocalProject(
       draftCode: script,
       deployedCode: '',
       deployedContracts: [],
-      state: '{}',
+      state: DEFAULT_ACCOUNT_STATE,
     };
   });
 


### PR DESCRIPTION
Fixes #365

- Remove refetchQueries from all mutations
- Clear the project accounts state/deployedCode/deployedContracts on contract redeployment
- Upgrade @apollo/react-hooks

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

