### PR TITLE
Hide deploy/send/execute btn loading state while project is auto-saving

### DIFF
--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -249,6 +249,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
     active: activeEditor,
     getActiveCode,
     isSavingCode,
+    isExecutingAction,
   } = useProject();
   const label = getLabel(type, project, activeEditor);
   const code = getActiveCode()[0].trim();
@@ -258,6 +259,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
         onClick={onClick}
         Icon={FaArrowCircleRight}
         disabled={isSavingCode || !active || code.length === 0}
+        hideDisabledState={isSavingCode && !isExecutingAction}
       >
         {label}
       </Button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,6 +11,7 @@ interface StyledButtonProps extends ChildProps {
   className?: string;
   onClick?: any;
   variant: string;
+  disabled?: boolean;
 }
 
 const StyledButton: React.FC<StyledButtonProps> = styled(ThemedButton)`
@@ -56,6 +57,10 @@ const StyledButton: React.FC<StyledButtonProps> = styled(ThemedButton)`
 
   cursor: ${({ variant }) =>
     variant === 'buttons.disabled' ? 'not-allowed !important' : 'pointer'};
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 `;
 
 interface ButtonProps extends ChildPropsOptional {
@@ -66,9 +71,8 @@ interface ButtonProps extends ChildPropsOptional {
   isLoading?: boolean;
   isActive?: boolean;
   disabled?: boolean;
+  hideDisabledState?: boolean;
 }
-
-const noop = (): void => {};
 
 const Button: React.FC<ButtonProps> = ({
   children,
@@ -79,14 +83,21 @@ const Button: React.FC<ButtonProps> = ({
   isLoading,
   isActive,
   disabled,
+  hideDisabledState,
 }) => {
+  const showDisabledState = disabled && !hideDisabledState;
   return (
     <motion.div whileHover={{ scale: 1.05 }}>
       <StyledButton
         style={style}
         className={className}
-        onClick={disabled ? noop : onClick}
-        variant={isActive && !disabled ? 'buttons.primary' : 'buttons.disabled'}
+        onClick={onClick}
+        variant={
+          isActive && !showDisabledState
+            ? 'buttons.primary'
+            : 'buttons.disabled'
+        }
+        disabled={disabled}
       >
         {children}
         {isLoading ? (

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -65,7 +65,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   // ===========================================================================
   // GLOBAL HOOKS
   const { languageClient } = useContext(CadenceCheckerContext);
-  const { project, active, isSavingCode } = useProject();
+  const { project, active, isExecutingAction } = useProject();
 
   // HOOKS  -------------------------------------------------------------------
   const [executionArguments, setExecutionArguments] = useState({});
@@ -366,10 +366,10 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
       break;
   }
 
-  const progress = isSavingCode || processingStatus;
+  const progress = isExecutingAction || processingStatus;
   if (progress) {
     statusIcon = <FaSpinner className="spin" />;
-    statusMessage = 'Please, wait...';
+    statusMessage = 'Please wait...';
   }
 
   // EFFECTS ------------------------------------------------------------------

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -67,6 +67,7 @@ export interface ProjectContextValue {
   setLastSigners: (signers: string[]) => void;
   transactionAccounts: number[];
   isSavingCode: boolean;
+  isExecutingAction: boolean;
 }
 
 export const ProjectContext: React.Context<ProjectContextValue> =
@@ -115,6 +116,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [initialLoad, setInitialLoad] = useState<boolean>(true);
   const [transactionAccounts, setTransactionAccounts] = useState<number[]>([0]);
   const [isSavingCode, setIsSaving] = useState(false);
+  const [isExecutingAction, setIsExecutingAction] = useState(false);
   const [lastSigners, setLastSigners] = useState(null);
 
   const [selectedResourceAccount, setSelectedResourceAccount] = useState<
@@ -161,6 +163,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
 
   const updateAccountDeployedCode: any = async () => {
     setIsSaving(true);
+    setIsExecutingAction(true);
     let res;
     try {
       res = await mutator.updateAccountDeployedCode(
@@ -176,9 +179,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     } catch (e) {
       console.error(e);
       setIsSaving(false);
+      setIsExecutingAction(false);
       showError();
     }
     setIsSaving(false);
+    setIsExecutingAction(false);
     return res;
   };
 
@@ -276,6 +281,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     args?: [string],
   ) => {
     setIsSaving(true);
+    setIsExecutingAction(true);
     let res;
     try {
       res = await mutator.createTransactionExecution(
@@ -295,14 +301,17 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     } catch (e) {
       console.error(e);
       setIsSaving(false);
+      setIsExecutingAction(false);
       showError();
     }
     setIsSaving(false);
+    setIsExecutingAction(false);
     return res;
   };
 
   const createScriptExecution = async (args?: string[]) => {
     setIsSaving(true);
+    setIsExecutingAction(true);
     let res;
     try {
       res = await mutator.createScriptExecution(
@@ -312,9 +321,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     } catch (e) {
       console.error(e);
       setIsSaving(false);
+      setIsExecutingAction(false);
       showError();
     }
     setIsSaving(false);
+    setIsExecutingAction(false);
     return res;
   };
 
@@ -530,6 +541,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         isLoading,
         mutator,
         isSavingCode,
+        isExecutingAction,
         updateProject,
         updateAccountDeployedCode,
         updateAccountDraftCode,


### PR DESCRIPTION
Auto-saving caused the action button to flash frequently as it was being disabled. This hides the visual disabled state while keeping the button disabled on auto-save.

Closes: #370

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

