### PR TITLE
Create blank projects and persist to localStorage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,7 +59,7 @@
         "ignoreCase": true
       }
     ],
-    "react/jsx-no-undef": 1,
+    "react/jsx-no-undef": 2,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,
     "jsx-a11y/alt-text": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "theme-ui": "^0.14.7",
         "unique-names-generator": "^4.7.1",
         "unreset-css": "^1.0.1",
+        "use-persisted-state": "^0.3.3",
         "vscode-jsonrpc": "^6.0.0"
       },
       "devDependencies": {
@@ -69,6 +70,7 @@
         "@types/react-helmet": "^6.1.5",
         "@types/react-icons": "^3.0.0",
         "@types/styled-components": "^5.1.26",
+        "@types/use-persisted-state": "^0.3.1",
         "@types/vscode": "^1.71.0",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -96,6 +98,9 @@
         "webpack-bundle-analyzer": "^4.6.1",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
+      },
+      "engines": {
+        "node": ">=16.0.0 <17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5093,6 +5098,15 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/use-persisted-state": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/use-persisted-state/-/use-persisted-state-0.3.1.tgz",
+      "integrity": "sha512-GZtzdCPeR+KZfrzKrVLnbpRcHSCVDHaFCJ0QtkXDAmh5M+eUJqGquFtN+eUOvAMIjwLgTZ2zKq0/JL+e1/gf8g==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.71.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.71.0.tgz",
@@ -5369,6 +5383,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -16492,6 +16514,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "dependencies": {
+        "@use-it/event-listener": "^0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -21429,6 +21462,15 @@
         "@types/estree": "*"
       }
     },
+    "@types/use-persisted-state": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/use-persisted-state/-/use-persisted-state-0.3.1.tgz",
+      "integrity": "sha512-GZtzdCPeR+KZfrzKrVLnbpRcHSCVDHaFCJ0QtkXDAmh5M+eUJqGquFtN+eUOvAMIjwLgTZ2zKq0/JL+e1/gf8g==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/vscode": {
       "version": "1.71.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.71.0.tgz",
@@ -21600,6 +21642,12 @@
         "@typescript-eslint/types": "5.38.0",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "requires": {}
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -30174,6 +30222,14 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "requires": {
+        "@use-it/event-listener": "^0.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "theme-ui": "^0.14.7",
     "unique-names-generator": "^4.7.1",
     "unreset-css": "^1.0.1",
+    "use-persisted-state": "^0.3.3",
     "vscode-jsonrpc": "^6.0.0"
   },
   "devDependencies": {
@@ -81,6 +82,7 @@
     "@types/react-helmet": "^6.1.5",
     "@types/react-icons": "^3.0.0",
     "@types/styled-components": "^5.1.26",
+    "@types/use-persisted-state": "^0.3.1",
     "@types/vscode": "^1.71.0",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -248,7 +248,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
     project,
     active: activeEditor,
     getActiveCode,
-    isSavingCode,
+    isSaving,
     isExecutingAction,
   } = useProject();
   const label = getLabel(type, project, activeEditor);
@@ -258,8 +258,8 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
       <Button
         onClick={onClick}
         Icon={FaArrowCircleRight}
-        disabled={isSavingCode || !active || code.length === 0}
-        hideDisabledState={isSavingCode && !isExecutingAction}
+        disabled={isSaving || !active || code.length === 0}
+        hideDisabledState={isSaving && !isExecutingAction}
       >
         {label}
       </Button>

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -141,7 +141,7 @@ type ProcessingArgs = {
 };
 
 const useTemplateType = (): ProcessingArgs => {
-  const { isSavingCode } = useProject();
+  const { isSaving } = useProject();
   const {
     createScriptExecution,
     createTransactionExecution,
@@ -149,7 +149,7 @@ const useTemplateType = (): ProcessingArgs => {
   } = useProject();
 
   return {
-    disabled: isSavingCode,
+    disabled: isSaving,
     scriptFactory: createScriptExecution,
     transactionFactory: createTransactionExecution,
     contractDeployment: updateAccountDeployedCode,
@@ -218,7 +218,7 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
   const {
     project,
     active,
-    isSavingCode,
+    isSaving,
     lastSigners,
     // updateAccountDeployedCode
   } = useProject();
@@ -356,7 +356,7 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
   let statusIcon = isOk ? <FaRegCheckCircle /> : <FaRegTimesCircle />;
   let statusMessage = isOk ? 'Ready' : 'Fix errors';
 
-  const progress = isSavingCode || processingStatus;
+  const progress = isSaving || processingStatus;
 
   if (progress) {
     statusIcon = <FaSpinner className="spin" />;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,17 +14,22 @@ interface ButtonProps extends ChildProps {
   sx?: ThemeUICSSObject;
 }
 
-const styles = {
+const getStyles = (disabled: boolean) => ({
   root: {
     display: 'flex',
     alignItems: 'center',
     gap: 4,
+    '&:hover': {
+      cursor: disabled ? 'default' : 'pointer',
+    },
   },
-};
+});
 
 const sizeStyles: Record<ButtonSizes, ThemeUICSSObject> = {
   sm: {
-    p: 4,
+    height: 34,
+    py: 2,
+    px: 4,
     fontSize: 1,
     color: 'text',
     borderRadius: '4px',
@@ -42,6 +47,7 @@ const Button = ({
   disabled,
   sx = {},
 }: ButtonProps) => {
+  const styles = getStyles(disabled);
   const mergedSx = { ...styles.root, ...sizeStyles[size], ...sx };
   return (
     <ThemeUiButton

--- a/src/components/CadenceEditor/ControlPanel/utils.tsx
+++ b/src/components/CadenceEditor/ControlPanel/utils.tsx
@@ -98,7 +98,7 @@ export const getLabel = (
 };
 
 export const useTemplateType = (): ProcessingArgs => {
-  const { isSavingCode } = useProject();
+  const { isSaving } = useProject();
   const {
     createScriptExecution,
     createTransactionExecution,
@@ -106,7 +106,7 @@ export const useTemplateType = (): ProcessingArgs => {
   } = useProject();
 
   return {
-    disabled: isSavingCode,
+    disabled: isSaving,
     scriptFactory: createScriptExecution,
     transactionFactory: createTransactionExecution,
     contractDeployment: updateAccountDeployedCode,

--- a/src/components/Icons/AnchorIcon.tsx
+++ b/src/components/Icons/AnchorIcon.tsx
@@ -4,10 +4,10 @@ function AnchorIcon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       fill="none"
-      viewBox="0 0 14 14"
+      viewBox="0 0 16 16"
     >
       <path
         fill="#000"

--- a/src/components/Icons/PlusIcon.tsx
+++ b/src/components/Icons/PlusIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function PlusIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        stroke="#2F353F"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M8 3.333v9.334M3.333 8h9.334"
+      />
+    </svg>
+  );
+}
+
+export default PlusIcon;

--- a/src/components/TopNav/ShareSaveButton.tsx
+++ b/src/components/TopNav/ShareSaveButton.tsx
@@ -1,0 +1,48 @@
+import Button from 'components/Button';
+import AnchorIcon from 'components/Icons/AnchorIcon';
+import { useProject } from 'providers/Project/projectHooks';
+import React from 'react';
+import { FaCloudUploadAlt, FaCodeBranch } from 'react-icons/fa';
+import useClipboard from 'react-use-clipboard';
+import Mixpanel from 'util/mixpanel';
+
+const ShareButton = () => {
+  const url = window.location.href;
+  const [isCopied, setCopied] = useClipboard(url, { successDuration: 2000 });
+
+  const onClick = () => {
+    setCopied();
+    Mixpanel.track('Share link copied', { url });
+  };
+
+  return (
+    <Button onClick={onClick} variant="alternate" size="sm">
+      {!isCopied ? 'Share' : 'Link Copied!'}
+      <AnchorIcon />
+    </Button>
+  );
+};
+
+const ShareSaveButton = () => {
+  const { project, isSaving, updateProject } = useProject();
+  const hasParent = !!project.parentId;
+  const text = hasParent ? 'Fork' : 'Save';
+  const onSaveButtonClick = () =>
+    updateProject(project.title, project.description, project.readme);
+
+  if (project.persist) return <ShareButton />;
+
+  return (
+    <Button
+      onClick={onSaveButtonClick}
+      variant="alternate"
+      disabled={isSaving}
+      size="sm"
+    >
+      {text}
+      {hasParent ? <FaCodeBranch /> : <FaCloudUploadAlt />}
+    </Button>
+  );
+};
+
+export default ShareSaveButton;

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -2,13 +2,15 @@ import Button from 'components/Button';
 import { Separator } from 'components/Common';
 import Examples from 'components/Examples';
 import ExportPopup from 'components/ExportPopup';
-import { AnimatedText, ShareSaveButton } from 'containers/Editor/components';
+import PlusIcon from 'components/Icons/PlusIcon';
+import { AnimatedText } from 'containers/Editor/components';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useState } from 'react';
 import { FaArrowAltCircleDown } from 'react-icons/fa';
 import { SXStyles } from 'src/types';
 import { Flex } from 'theme-ui';
 import Mixpanel from 'util/mixpanel';
+import ShareSaveButton from './ShareSaveButton';
 import ExternalNavLinks from './TopNavButton';
 
 const styles: SXStyles = {
@@ -42,7 +44,7 @@ const styles: SXStyles = {
 };
 
 const TopNav = () => {
-  const { project, updateProject } = useProject();
+  const { project, createBlankProject, isSaving } = useProject();
   const [showExport, setShowExport] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
 
@@ -51,12 +53,18 @@ const TopNav = () => {
     Mixpanel.track('Show examples', { meta: 'none' });
   };
 
-  const onSaveButtonClick = () =>
-    updateProject(project.title, project.description, project.readme);
-
   return (
     <Flex sx={styles.root}>
-      <Flex sx={styles.topNavSection} />
+      <Flex sx={styles.topNavSection}>
+        <Button
+          onClick={createBlankProject}
+          variant="alternate"
+          size="sm"
+          disabled={isSaving}
+        >
+          <PlusIcon />
+        </Button>
+      </Flex>
       <Flex sx={styles.topNavSection}>
         <Button variant="secondary" onClick={onStartButtonClick}>
           <AnimatedText>Click here to start a tutorial</AnimatedText>
@@ -75,12 +83,7 @@ const TopNav = () => {
               Export
               <FaArrowAltCircleDown />
             </Button>
-            <ShareSaveButton
-              url={window.location.href}
-              hasParent={!!project.parentId}
-              showShare={project.persist}
-              onSave={onSaveButtonClick}
-            />
+            <ShareSaveButton />
           </>
         )}
       </Flex>

--- a/src/containers/Editor/components.tsx
+++ b/src/containers/Editor/components.tsx
@@ -11,11 +11,7 @@ import {
 } from 'providers/Project/projectDefault';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useEffect, useRef, useState } from 'react';
-import { FaCloudUploadAlt, FaCodeBranch } from 'react-icons/fa';
-import useClipboard from 'react-use-clipboard';
 import { Divider, Flex } from 'theme-ui';
-
-import Mixpanel from 'util/mixpanel';
 
 // import CadenceEditor from 'components/CadenceEditor';
 import {
@@ -37,9 +33,7 @@ import {
   ReadmeHtmlContainer,
 } from './layout-components';
 
-import Button from 'components/Button';
 import CadenceEditor from 'components/CadenceEditor';
-import AnchorIcon from 'components/Icons/AnchorIcon';
 import { ChildProps } from 'src/types';
 import { decodeText } from 'util/readme';
 
@@ -64,51 +58,6 @@ const Header = ({ children }: ChildProps) => {
         {children}
       </Flex>
     </motion.div>
-  );
-};
-
-const ShareButton = ({ url }: { url: string }) => {
-  const [isCopied, setCopied] = useClipboard(url, { successDuration: 2000 });
-  const onClick = () => {
-    setCopied();
-    Mixpanel.track('Share link copied', { url });
-  };
-  return (
-    <Button onClick={onClick} variant="alternate" size="sm">
-      {!isCopied ? 'Share' : 'Link Copied!'}
-      <AnchorIcon />
-    </Button>
-  );
-};
-
-type ShareSaveButtonProps = {
-  url: string;
-  hasParent: boolean;
-  showShare: boolean;
-  onSave: () => void;
-};
-
-const ShareSaveButton = ({
-  url,
-  hasParent,
-  showShare,
-  onSave,
-}: ShareSaveButtonProps) => {
-  const { isSavingCode } = useProject();
-  const text = hasParent ? 'Fork' : 'Save';
-
-  if (showShare) return <ShareButton url={url} />;
-
-  return (
-    <Button
-      onClick={onSave}
-      variant="alternate"
-      disabled={isSavingCode}
-      size="sm"
-    >
-      {text}
-      {hasParent ? <FaCodeBranch /> : <FaCloudUploadAlt />}
-    </Button>
   );
 };
 
@@ -352,4 +301,4 @@ const AnimatedText = styled.div`
   }
 `;
 
-export { EditorContainer, Header, ShareSaveButton, AnimatedText };
+export { EditorContainer, Header, AnimatedText };

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -135,8 +135,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const readme = project ? project.readme : null;
   const [persistedProjectIds, setPersistedProjectIds] =
     usePersistedProjectIdsState([]);
-  console.log(persistedProjectIds);
-  const persistProject = (id: Scalars['UUID']) => {
+
+  const persistToLocalStorage = (id: Scalars['UUID']) => {
     setPersistedProjectIds((prev: string[]) => [...prev, id]);
   };
 
@@ -147,7 +147,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     title,
     description,
     readme,
-    persistProject,
+    persistToLocalStorage,
   );
 
   const showError = () => alert('Something went wrong, please try again');


### PR DESCRIPTION
- Create a blank project when clicking the + in top nav
- Mark project as persisted. This will happen in a single query in the upcoming api
- Persist project ids to localStorage with use-persisted-state

<img width="427" alt="image" src="https://user-images.githubusercontent.com/1160249/195440173-8fcc483e-b0b2-4e2d-b59d-edc388a4197e.png">

Closes: #346
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

