### PR TITLE
Signer panel styling

### DIFF
--- a/src/components/AccountPicker.tsx
+++ b/src/components/AccountPicker.tsx
@@ -42,28 +42,20 @@ const AccountPicker = ({
 
   return (
     <Flex
+      my={1}
       sx={{
-        flexDirection: 'column',
+        padding: '0 0.5rem 0.5rem 0.5rem',
+        alignItems: 'flex-start',
       }}
     >
-      <Flex
-        my={1}
-        sx={{
-          padding: '0.8rem 0.5rem',
-          alignItems: 'center',
-          backgroundColor: theme.colors.background,
-        }}
-      >
-        <AccountAvatars
-          multi={true}
-          project={project}
-          accounts={accounts}
-          selectedAccounts={selected}
-          onChange={(index: number) => handleOnChange(index, maxSelection)}
-          maxSelection={maxSelection}
-        />
-      </Flex>
-
+      <AccountAvatars
+        multi={true}
+        project={project}
+        accounts={accounts}
+        selectedAccounts={selected}
+        onChange={(index: number) => handleOnChange(index, maxSelection)}
+        maxSelection={maxSelection}
+      />
     </Flex>
   );
 };

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -14,7 +14,7 @@ interface ActionButtonProps extends ChildPropsOptional {
   'data-test'?: string;
 }
 
-const ActionButton: React.FC<ActionButtonProps> = (props) => {
+const ActionButton: React.FC<ActionButtonProps> = (props: ActionButtonProps) => {
   return (
     <motion.div
       style={{

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -1,6 +1,5 @@
 import { Project } from 'api/apollo/generated/graphql';
-import AccountPicker from 'components/AccountPicker';
-import Button from 'components/LegacyButton';
+import PanelButton from 'components/PanelButton';
 import { Stack } from 'layout/Stack';
 import { ActiveEditor, EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
@@ -9,7 +8,6 @@ import {
   FaArrowCircleRight,
   FaCaretSquareDown,
   FaCaretSquareUp,
-  FaExclamationTriangle,
 } from 'react-icons/fa';
 import { CadenceProblem } from 'util/language-syntax-errors';
 import theme from '../../theme';
@@ -21,8 +19,6 @@ import {
   ErrorMessage,
   Heading,
   List,
-  SignersContainer,
-  SignersError,
   SingleError,
   Title,
 } from './styles';
@@ -34,7 +30,7 @@ import {
   InteractionButtonProps,
 } from './types';
 
-export const ArgumentsTitle: React.FC<ArgumentsTitleProps> = (props) => {
+export const ArgumentsTitle: React.FC<ArgumentsTitleProps> = (props: ArgumentsTitleProps) => {
   const { type, errors, expanded, setExpanded } = props;
 
   const hasErrors = errors > 0;
@@ -68,7 +64,7 @@ export const ArgumentsList: React.FC<ArgumentsListProps> = ({
   errors,
   onChange,
   hidden,
-}) => {
+}: ArgumentsListProps) => {
   return (
     <List hidden={hidden}>
       {list.map((argument) => {
@@ -134,7 +130,7 @@ const renderMessage = (message: string) => {
   return items;
 };
 
-export const ErrorsList: React.FC<ErrorListProps> = (props) => {
+export const ErrorsList: React.FC<ErrorListProps> = (props: ErrorListProps) => {
   const { list, actions } = props;
   const { goTo, hideDecorations, hover } = actions;
   if (list.length === 0) {
@@ -144,9 +140,6 @@ export const ErrorsList: React.FC<ErrorListProps> = (props) => {
 
   return (
     <Stack>
-      <Heading>
-        <Title lineColor={theme.colors.error}>Problems</Title>
-      </Heading>
       <List>
         {list.map((item: CadenceProblem, i) => {
           const message = renderMessage(item.message);
@@ -267,7 +260,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
   const code = getActiveCode()[0].trim();
   return (
     <Controls>
-      <Button
+      <PanelButton
         onClick={onClick}
         Icon={FaArrowCircleRight}
         disabled={isSaving || !active || code.length === 0}
@@ -275,40 +268,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
         data-test={getActionButtonTestTag(type)}
       >
         {label}
-      </Button>
+      </PanelButton>
     </Controls>
-  );
-};
-
-type SignersProps = {
-  maxSelection?: number;
-  selected: number[];
-  updateSelectedAccounts: (selection: number[]) => void;
-};
-
-const Signers: React.FC<SignersProps> = ({ maxSelection, selected, updateSelectedAccounts }) => {
-  const { project } = useProject();
-  const { accounts } = project;
-
-  const enoughSigners = selected.length < maxSelection;
-  const lineColor = enoughSigners ? theme.colors.error : null;
-
-  return (
-    <SignersContainer>
-      <Title lineColor={lineColor}>Transaction Signers</Title>
-      <AccountPicker
-        project={project}
-        accounts={accounts}
-        selected={selected}
-        onChange={updateSelectedAccounts}
-        maxSelection={maxSelection}
-      />
-      {enoughSigners && (
-        <SignersError>
-          <FaExclamationTriangle />
-          Not enough signers...
-        </SignersError>
-      )}
-    </SignersContainer>
   );
 };

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -248,7 +248,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
   type,
   active = true,
   onClick,
-}: {type: EntityType, active: boolean, onClick: Function}) => {
+}: InteractionButtonProps) => {
   const {
     project,
     active: activeEditor,

--- a/src/components/Arguments/components.tsx
+++ b/src/components/Arguments/components.tsx
@@ -286,7 +286,7 @@ type SignersProps = {
   updateSelectedAccounts: (selection: number[]) => void;
 };
 
-export const Signers: React.FC<SignersProps> = ({ maxSelection, selected, updateSelectedAccounts }) => {
+const Signers: React.FC<SignersProps> = ({ maxSelection, selected, updateSelectedAccounts }) => {
   const { project } = useProject();
   const { accounts } = project;
 

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -358,7 +358,7 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
 
   const isOk = !haveErrors && validCode !== undefined && !!validCode;
   //let statusIcon = isOk ? <FaRegCheckCircle /> : <FaRegTimesCircle />;
-  let statusMessage = isOk ? 'Ready' : `${problems?.error?.length} Errors`;
+  let statusMessage = !isOk && `${problems?.error?.length} Errors`;
 
   const progress = isSaving || processingStatus;
 
@@ -414,11 +414,13 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
           <Hints problems={problems} actions={actions} />
 
           <ControlContainer isOk={isOk} progress={progress}>
-            <StatusMessage>
-              <FaRegTimesCircle />
-              <p>{statusMessage}</p>
-            </StatusMessage>
-            <ActionButton active={isOk} type={type} onClick={send} />
+            {statusMessage && 
+              <StatusMessage>
+                <FaRegTimesCircle />
+                <p>{statusMessage}</p>
+              </StatusMessage>
+            }
+            <ActionButton progress={progress} active={isOk} type={type} onClick={send} />
           </ControlContainer>
         </HoverPanel>
       </motion.div>

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -357,13 +357,11 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
   };
 
   const isOk = !haveErrors && validCode !== undefined && !!validCode;
-  //let statusIcon = isOk ? <FaRegCheckCircle /> : <FaRegTimesCircle />;
   let statusMessage = !isOk && `${problems?.error?.length} Errors`;
 
   const progress = isSaving || processingStatus;
 
   if (progress) {
-    //statusIcon = <FaSpinner className="spin" />;
     statusMessage = 'Please, wait...';
   }
 

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -28,7 +28,6 @@ import {
   ArgumentsTitle,
   ErrorsList,
   Hints,
-  Signers,
 } from './components';
 import { SignersPanel } from 'components/SignersPanel';
 

--- a/src/components/Arguments/index.tsx
+++ b/src/components/Arguments/index.tsx
@@ -357,13 +357,13 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
   };
 
   const isOk = !haveErrors && validCode !== undefined && !!validCode;
-  let statusIcon = isOk ? <FaRegCheckCircle /> : <FaRegTimesCircle />;
-  let statusMessage = isOk ? 'Ready' : 'Fix errors';
+  //let statusIcon = isOk ? <FaRegCheckCircle /> : <FaRegTimesCircle />;
+  let statusMessage = isOk ? 'Ready' : `${problems?.error?.length} Errors`;
 
   const progress = isSaving || processingStatus;
 
   if (progress) {
-    statusIcon = <FaSpinner className="spin" />;
+    //statusIcon = <FaSpinner className="spin" />;
     statusMessage = 'Please, wait...';
   }
 
@@ -410,12 +410,12 @@ const Arguments: React.FC<ArgumentsProps> = (props) => {
             </>
           )}
 
-          <ErrorsList list={problems.error} actions={actions} />
+          {/*<ErrorsList list={problems.error} actions={actions} />*/}
           <Hints problems={problems} actions={actions} />
 
           <ControlContainer isOk={isOk} progress={progress}>
             <StatusMessage>
-              {statusIcon}
+              <FaRegTimesCircle />
               <p>{statusMessage}</p>
             </StatusMessage>
             <ActionButton active={isOk} type={type} onClick={send} />

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -110,7 +110,6 @@ interface ControlContainerProps {
 }
 export const ControlContainer = styled.div<ControlContainerProps>`
   display: ${({ showPrompt }) => (showPrompt ? 'block' : 'flex')};
-  max-width: ${({ showPrompt }) => (showPrompt ? 'min-content' : 'none')};
   align-items: center;
   justify-content: space-between;
   padding: 8px;
@@ -152,7 +151,8 @@ export const StatusMessage = styled.div`
   }
 
   display: flex;
-  width: 50%;
+  width: ${({ isOk }) => isOk ? '100%' : '50%'};
+  padding: ${({ isOk }) => isOk ? '1rem' : 'unset'};
   justify-content: flex-start;
   font-size: 16px;
   svg {

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -58,6 +58,7 @@ export const Controls = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  width: 100%;
   cursor: pointer;
 `;
 
@@ -113,6 +114,7 @@ export const ControlContainer = styled.div<ControlContainerProps>`
   align-items: center;
   justify-content: space-between;
   padding: 8px;
+  width: 100%;
   border-top: 1px solid #ABB3BF;
   color: ${({ isOk, progress, showPrompt }) => {
     switch (true) {
@@ -150,6 +152,7 @@ export const StatusMessage = styled.div`
   }
 
   display: flex;
+  width: 50%;
   justify-content: flex-start;
   font-size: 16px;
   svg {
@@ -166,6 +169,8 @@ export const ErrorsContainer = styled.div`
   grid-gap: 10px;
   grid-template-columns: 100%;
   margin-bottom: 12px;
+  background: #F6F7F9;
+  border-radius: 8px 8px 8px 0px;
 `;
 
 export const SingleError = styled.div`
@@ -174,8 +179,10 @@ export const SingleError = styled.div`
   align-items: baseline;
   box-sizing: border-box;
   padding: 10px;
-  border-radius: 4px;
   font-size: 14px;
+  background: #FFFFFF;
+  box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
   &:hover {
     background-color: rgba(244, 57, 64, 0.15);
 
@@ -190,15 +197,9 @@ export const SingleError = styled.div`
 `;
 
 export const ErrorIndex = styled.div`
-  width: 20px;
-  height: 20px;
-  background-color: rgba(0, 0, 0, 0.15);
   display: flex;
   align-items: center;
-  justify-content: center;
-  border-radius: 20px;
-  margin-right: 8px;
-  flex: 0 0 auto;
+  justify-content: space-between;
 `;
 
 export const ErrorMessage = styled.p`

--- a/src/components/Arguments/styles.tsx
+++ b/src/components/Arguments/styles.tsx
@@ -8,10 +8,10 @@ interface HoverPanelProps {
 export const HoverPanel = styled.div<HoverPanelProps>`
   min-width: ${({ minWidth }) => minWidth};
   max-width: 300px;
-  padding: 20px;
-  border-radius: 4px;
+  border-radius: 8px;
   background-color: #fff;
-  box-shadow: 10px 10px 20px #c9c9c9, -10px -10px 20px #ffffff;
+  border: 1px solid #ABB3BF;
+  box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.08);
 `;
 
 interface HidableProps {
@@ -99,7 +99,7 @@ export const List = styled.div<ListProps>`
 `;
 
 export const SignersContainer = styled.div`
-  margin-bottom: 20px;
+  
 `;
 
 interface ControlContainerProps {
@@ -112,6 +112,8 @@ export const ControlContainer = styled.div<ControlContainerProps>`
   max-width: ${({ showPrompt }) => (showPrompt ? 'min-content' : 'none')};
   align-items: center;
   justify-content: space-between;
+  padding: 8px;
+  border-top: 1px solid #ABB3BF;
   color: ${({ isOk, progress, showPrompt }) => {
     switch (true) {
       case progress:

--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -253,9 +253,8 @@ export const Cancel = styled(LegacyButton)`
 `;
 
 export const PromptActionsContainer = styled.div`
-  padding-top: 1rem;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 `;
 
 interface StatusIconProps {

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -52,7 +52,6 @@ import {
   ArgumentsTitle,
   ErrorsList,
   Hints,
-  Signers,
 } from '../../Arguments/components';
 import {
   ControlContainer,
@@ -336,9 +335,9 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   const problems = getProblems();
   const validCode = problems.error.length === 0;
 
-  const signers = extractSigners(code).length;
-  const needSigners = type == EntityType.TransactionTemplate && signers > 0;
-
+  // contracts need one signer for deployment
+  const signers = type === EntityType.TransactionTemplate ? extractSigners(code).length : 1;
+  const needSigners = type === EntityType.TransactionTemplate && signers > 0 || type == EntityType.ContractTemplate;
   const numberOfErrors = Object.keys(errors).length;
 
   // TODO: disable button if not enough signers
@@ -346,7 +345,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   const haveErrors = numberOfErrors > 0
 
   const { accounts } = project;
-  const signersAccounts = selected.map((i) => accounts[i]);
+  const signersAccounts = selected.map((i: number) => accounts[i]);
 
   const actions = {
     goTo: (position: IPosition) => goTo(editor, position),
@@ -354,7 +353,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     hover: (highlight: Highlight) => hover(editor, highlight),
   };
 
-  const isOk = !haveErrors && validCode !== undefined && !!validCode;
+  const isOk = !haveErrors && validCode !== undefined && !!validCode && !notEnoughSigners;
   let statusIcon;
   let statusMessage;
   switch (true) {

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -435,7 +435,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             showPrompt={showPrompt}
           >
             {statusMessage && (
-              <StatusMessage data-test="control-panel-status-message">
+              <StatusMessage isOk={isOk} data-test="control-panel-status-message">
                 <StatusIcon
                   isOk={isOk}
                   progress={progress}

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -364,7 +364,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
       break;
     case !isOk:
       statusIcon = <FaRegTimesCircle />;
-      statusMessage = 'Fix errors';
+      statusMessage = `${problems?.error?.length} Error${problems?.error?.length > 1 ? 's' : ''}`;
       break;
   }
 
@@ -397,37 +397,36 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
       <div ref={constraintsRef} className="constraints" />
       <MotionBox dragConstraints={constraintsRef}>
         <HoverPanel minWidth={showPrompt ? 'min-content' : '300px'}>
-          <Hidable hidden={!validCode}>
-            {list.length > 0 && (
-              <>
-                <ArgumentsTitle
-                  type={type}
-                  errors={numberOfErrors}
-                  expanded={expanded}
-                  setExpanded={setExpanded}
-                />
-                <ArgumentsList
-                  list={list}
-                  errors={errors}
-                  hidden={!expanded}
-                  onChange={(name, value) => {
-                    let key = name.toString();
-                    let newValue = { ...values, [key]: value };
-                    setValue(newValue);
-                  }}
-                />
-              </>
-            )}
-            {needSigners && (
-              <SignersPanel
-                maxSelection={signers}
-                selected={selected}
-                updateSelectedAccounts={updateSelectedAccounts}
+          {list.length > 0 && (
+            <>
+              <ArgumentsTitle
+                type={type}
+                errors={numberOfErrors}
+                expanded={expanded}
+                setExpanded={setExpanded}
               />
-            )}
-          </Hidable>
+              <ArgumentsList
+                list={list}
+                errors={errors}
+                hidden={!expanded}
+                onChange={(name, value) => {
+                  let key = name.toString();
+                  let newValue = { ...values, [key]: value };
+                  setValue(newValue);
+                }}
+              />
+            </>
+          )}
+          {needSigners && (
+            <SignersPanel
+              maxSelection={signers}
+              selected={selected}
+              updateSelectedAccounts={updateSelectedAccounts}
+            />
+          )}
 
-          <ErrorsList list={problems.error} actions={actions} />
+
+          {/*<ErrorsList list={problems.error} actions={actions} />*/}
           <Hints problems={problems} actions={actions} />
 
           <ControlContainer
@@ -435,16 +434,18 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             progress={progress}
             showPrompt={showPrompt}
           >
-            <StatusMessage data-test="control-panel-status-message">
-              <StatusIcon
-                isOk={isOk}
-                progress={progress}
-                showPrompt={showPrompt}
-              >
-                {statusIcon}
-              </StatusIcon>
-              <p>{statusMessage}</p>
-            </StatusMessage>
+            {statusMessage && (
+              <StatusMessage data-test="control-panel-status-message">
+                <StatusIcon
+                  isOk={isOk}
+                  progress={progress}
+                  showPrompt={showPrompt}
+                >
+                  {statusIcon}
+                </StatusIcon>
+                <p>{statusMessage}</p>
+              </StatusMessage>)
+            }
             {showPrompt ? (
               <PromptActionsContainer>
                 <Confirm data-test="redeploy-confirm-button" onClick={send}>

--- a/src/components/Icons/CheckMark.tsx
+++ b/src/components/Icons/CheckMark.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+function CheckMarkIcon() {
+    return (
+        <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M13.8333 4L6.49996 11.3333L3.16663 8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>)
+}
+
+export default CheckMarkIcon;

--- a/src/components/Icons/CheckMark.tsx
+++ b/src/components/Icons/CheckMark.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 function CheckMarkIcon() {
     return (
-        <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M13.8333 4L6.49996 11.3333L3.16663 8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>)
+      <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M13.8333 4L6.49996 11.3333L3.16663 8" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>)
 }
 
 export default CheckMarkIcon;

--- a/src/components/Icons/CheckMark.tsx
+++ b/src/components/Icons/CheckMark.tsx
@@ -4,7 +4,8 @@ function CheckMarkIcon() {
     return (
       <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M13.8333 4L6.49996 11.3333L3.16663 8" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>)
+      </svg>
+    )
 }
 
 export default CheckMarkIcon;

--- a/src/components/Icons/CollapseOpenIcon.tsx
+++ b/src/components/Icons/CollapseOpenIcon.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 function CollapseOpenIcon() {
     return (
-        <svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M9 5L5 1L1 5" stroke="#2F353F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
+      <svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M9 5L5 1L1 5" stroke="#2F353F" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
     )
 }
 

--- a/src/components/PanelButton.tsx
+++ b/src/components/PanelButton.tsx
@@ -1,0 +1,52 @@
+import { motion } from 'framer-motion';
+import React from 'react';
+import theme from '../theme';
+import { ChildPropsOptional } from 'src/types';
+import { CSSProperties } from 'styled-components';
+import Button from './Button';
+import CheckMarkIcon from './Icons/CheckMark';
+
+interface PanelButtonProps extends ChildPropsOptional {
+  onClick?: any;
+  className?: string;
+  style?: CSSProperties;
+  Icon?: any;
+  isLoading?: boolean;
+  isComplete?: boolean;
+  isActive?: boolean;
+  disabled?: boolean;
+  hideDisabledState?: boolean;
+  'data-test'?: string;
+}
+
+const PanelButton: React.FC<PanelButtonProps> = (props) => {
+    // TODO: what is hideDisabledState used for
+
+    const getStyle = ({disabled, isComplete}: PanelButtonProps) => {
+        if (disabled) return theme.colors.grey;
+        if (isComplete) return theme.colors.primary;
+        return theme.colors.black
+    }
+
+    const sx = {
+        ...props.style,
+        backgroundColor: getStyle(props),
+        color: theme.colors.white,
+    }
+
+  return (
+    <motion.div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+      }}
+      whileTap={{ scale: 0.95 }}
+    >
+      <Button {...props} sx={sx} disabled={props.disabled || props.hideDisabledState}>{props.isComplete && CheckMarkIcon()}{props.children}</Button>
+    </motion.div>
+  );
+};
+
+export default PanelButton;

--- a/src/components/SignersPanel/index.tsx
+++ b/src/components/SignersPanel/index.tsx
@@ -1,5 +1,5 @@
 import { useProject } from 'providers/Project/projectHooks';
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import theme from '../../theme';
 import AccountPicker from 'components/AccountPicker';
 import { Flex, Text } from 'theme-ui';
@@ -7,7 +7,6 @@ import { SXStyles } from 'src/types';
 import {
   SignersContainer,
 } from '../Arguments/styles';
-import { Account } from 'api/apollo/generated/graphql';
 import Avatar from 'components/Avatar';
 import CollapseOpenIcon from 'components/Icons/CollapseOpenIcon';
 import Button from 'components/Button';
@@ -17,10 +16,6 @@ type SignersProps = {
   selected: number[];
   updateSelectedAccounts: (selection: number[]) => void;
 };
-
-const displayAddress = ({ address }: { address: string }) => {
-  return `0x${address.slice(-2)}`;
-}
 
 const AvatarIcon = (seed: number, index: number, complete: boolean) => {
   return (
@@ -47,8 +42,7 @@ const AvatarIconList = (seed: number, indexes: number[], complete: boolean = fal
   )
 }
 
-const PanelHeader = (maxSelection: number, accounts: Account[], seed: number, selected: number[] = []) => {
-  // TODO: accounts might be needed for displaying account addr, to be determined
+const PanelHeader = (maxSelection: number, seed: number, selected: number[] = []) => {
   let message = ""
   const correctNumSigners = selected.length === maxSelection;
   const SIGNERSSELECTED = "Signers Selected";
@@ -61,9 +55,9 @@ const PanelHeader = (maxSelection: number, accounts: Account[], seed: number, se
   }
 
   return (
-    <Flex sx={{ justifyContent: "flex-start" }}>
+    <Flex sx={{ justifyContent: "flex-start", padding: " 0.875rem" }}>
       {AvatarIconList(seed, selected, correctNumSigners)}
-      <Text sx={{marginLeft: '0.25rem'}}>{message}</Text>
+      <Text sx={{marginLeft: '0.25rem', fontSize: '14px'}}>{message}</Text>
     </Flex>
   )
 }
@@ -71,12 +65,12 @@ const PanelHeader = (maxSelection: number, accounts: Account[], seed: number, se
 const styles: SXStyles = {   
   root: {
     backgroundColor: theme.colors.white,
-    width: '50px'
+    width: '3rem'
   },
   carrotDown: {
     backgroundColor: theme.colors.white,
     transform: 'rotate(180deg)',
-    width: '50px'
+    width: '3rem'
   },
 };
 
@@ -85,8 +79,14 @@ export const SignersPanel: React.FC<SignersProps> = ({ maxSelection, selected, u
   const [isAvatarOpen, setIsAvatarOpen] = useState(false);
   const { accounts } = project;
 
-  const HeaderText = useMemo(() => PanelHeader(maxSelection, accounts, project.seed, selected), [maxSelection, accounts, selected, project.seed])
+  const HeaderText = useMemo(() => PanelHeader(maxSelection, project.seed, selected), [maxSelection, selected, project.seed])
 
+  useEffect(() => {
+    if (selected.length === 0 && maxSelection > 0) {
+      updateSelectedAccounts([0]) // select first signer as default
+    }
+  }, [maxSelection, selected, updateSelectedAccounts])
+  
   return (
     <SignersContainer>
       <Flex sx={{ justifyContent: "space-between", alignItems: "center" }} onClick={() => setIsAvatarOpen(!isAvatarOpen)}>


### PR DESCRIPTION
Closes: #404 
Closes: #410 

 - format signer panel
 - style action button
 - show error count and hide error list
 - added types usage where they were missing
 - convert a few 'px' to use 'rem'
 - commented out Error list, will need to style it when the time comes. 
 
 Currently deploying contacts or running scripts fail, when that gets worked out I'll be able to finish "completed" button states.

![2022-11-08 14 46 01](https://user-images.githubusercontent.com/3970376/200672160-85f9e194-2fc1-4061-ac7e-43834e8f6071.gif)


massage redeploy confirmation dialog.
![image](https://user-images.githubusercontent.com/3970376/200681890-5c31bbfd-b52c-431f-9679-ca28ac20d499.png)
