### PR TITLE
Wire project read data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "webpack-dev-server": "^4.11.1"
       },
       "engines": {
-        "node": ">=16.0.0 <18.0.0"
+        "node": ">=16.0.0 <17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -82,6 +82,7 @@ export type Mutation = {
   createTransactionExecution: TransactionExecution;
   createTransactionTemplate: TransactionTemplate;
   deleteContractTemplate: Scalars['UUID'];
+  deleteProject: Scalars['UUID'];
   deleteScriptTemplate: Scalars['UUID'];
   deleteTransactionTemplate: Scalars['UUID'];
   setActiveProjectId?: Maybe<Scalars['Boolean']>;
@@ -135,6 +136,11 @@ export type MutationCreateTransactionTemplateArgs = {
 
 export type MutationDeleteContractTemplateArgs = {
   id: Scalars['UUID'];
+  projectId: Scalars['UUID'];
+};
+
+
+export type MutationDeleteProjectArgs = {
   projectId: Scalars['UUID'];
 };
 
@@ -288,6 +294,7 @@ export type Project = {
   seed: Scalars['Int'];
   version: Scalars['Version'];
   persist?: Maybe<Scalars['Boolean']>;
+  updatedAt: Scalars['String'];
   mutable?: Maybe<Scalars['Boolean']>;
   numberOfAccounts: Scalars['Int'];
   accounts?: Maybe<Array<Account>>;
@@ -297,6 +304,11 @@ export type Project = {
   scriptExecutions?: Maybe<Array<ScriptExecution>>;
   contractTemplates?: Maybe<Array<ContractTemplate>>;
   contractDeployments?: Maybe<Array<ContractDeployment>>;
+};
+
+export type ProjectList = {
+  __typename?: 'ProjectList';
+  projects?: Maybe<Array<Project>>;
 };
 
 export type Query = {
@@ -309,6 +321,7 @@ export type Query = {
   localProject?: Maybe<Project>;
   playgroundInfo: PlaygroundInfo;
   project: Project;
+  projectList: ProjectList;
   projects: Array<Maybe<Project>>;
   scriptTemplate: ScriptTemplate;
   transactionTemplate: TransactionTemplate;
@@ -710,6 +723,16 @@ export type CreateScriptExecutionMutation = (
   ) }
 );
 
+export type DeleteProjectMutationVariables = Exact<{
+  projectId: Scalars['UUID'];
+}>;
+
+
+export type DeleteProjectMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'deleteProject'>
+);
+
 export type SetExecutionResultsMutationVariables = Exact<{
   resultType: ResultType;
   rawResult: Scalars['RawExecutionResult'];
@@ -739,7 +762,7 @@ export type GetProjectsQuery = (
   { __typename?: 'Query' }
   & { projects: Array<Maybe<(
     { __typename?: 'Project' }
-    & Pick<Project, 'id' | 'title'>
+    & Pick<Project, 'id' | 'updatedAt' | 'title'>
     & { contractTemplates?: Maybe<Array<(
       { __typename?: 'ContractTemplate' }
       & Pick<ContractTemplate, 'id' | 'script' | 'title'>
@@ -762,7 +785,7 @@ export type GetProjectQuery = (
   { __typename?: 'Query' }
   & { project: (
     { __typename?: 'Project' }
-    & Pick<Project, 'id' | 'persist' | 'mutable' | 'parentId' | 'seed' | 'title' | 'description' | 'readme'>
+    & Pick<Project, 'id' | 'persist' | 'mutable' | 'parentId' | 'updatedAt' | 'seed' | 'title' | 'description' | 'readme'>
     & { accounts?: Maybe<Array<(
       { __typename?: 'Account' }
       & Pick<Account, 'address' | 'deployedContracts' | 'state'>
@@ -1568,6 +1591,36 @@ export function useCreateScriptExecutionMutation(baseOptions?: ApolloReactHooks.
 export type CreateScriptExecutionMutationHookResult = ReturnType<typeof useCreateScriptExecutionMutation>;
 export type CreateScriptExecutionMutationResult = ApolloReactCommon.MutationResult<CreateScriptExecutionMutation>;
 export type CreateScriptExecutionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
+export const DeleteProjectDocument = gql`
+    mutation DeleteProject($projectId: UUID!) {
+  deleteProject(projectId: $projectId)
+}
+    `;
+export type DeleteProjectMutationFn = ApolloReactCommon.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+
+/**
+ * __useDeleteProjectMutation__
+ *
+ * To run a mutation, you first call `useDeleteProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteProjectMutation, { data, loading, error }] = useDeleteProjectMutation({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useDeleteProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
+        return ApolloReactHooks.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
+      }
+export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
+export type DeleteProjectMutationResult = ApolloReactCommon.MutationResult<DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
 export const SetExecutionResultsDocument = gql`
     mutation SetExecutionResults($resultType: ResultType!, $rawResult: RawExecutionResult!, $label: String) {
   updateCachedExecutionResults(
@@ -1638,6 +1691,7 @@ export const GetProjectsDocument = gql`
     query GetProjects {
   projects @client {
     id
+    updatedAt
     title
     contractTemplates {
       id
@@ -1689,6 +1743,7 @@ export const GetProjectDocument = gql`
     persist
     mutable
     parentId
+    updatedAt
     seed
     title
     description

--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -760,20 +760,23 @@ export type GetProjectsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetProjectsQuery = (
   { __typename?: 'Query' }
-  & { projects: Array<Maybe<(
-    { __typename?: 'Project' }
-    & Pick<Project, 'id' | 'updatedAt' | 'title'>
-    & { contractTemplates?: Maybe<Array<(
-      { __typename?: 'ContractTemplate' }
-      & Pick<ContractTemplate, 'id' | 'script' | 'title'>
-    )>>, transactionTemplates?: Maybe<Array<(
-      { __typename?: 'TransactionTemplate' }
-      & Pick<TransactionTemplate, 'id' | 'script' | 'title'>
-    )>>, scriptTemplates?: Maybe<Array<(
-      { __typename?: 'ScriptTemplate' }
-      & Pick<ScriptTemplate, 'id' | 'script' | 'title'>
+  & { projectList: (
+    { __typename?: 'ProjectList' }
+    & { projects?: Maybe<Array<(
+      { __typename?: 'Project' }
+      & Pick<Project, 'id' | 'updatedAt' | 'title'>
+      & { contractTemplates?: Maybe<Array<(
+        { __typename?: 'ContractTemplate' }
+        & Pick<ContractTemplate, 'id' | 'script' | 'title'>
+      )>>, transactionTemplates?: Maybe<Array<(
+        { __typename?: 'TransactionTemplate' }
+        & Pick<TransactionTemplate, 'id' | 'script' | 'title'>
+      )>>, scriptTemplates?: Maybe<Array<(
+        { __typename?: 'ScriptTemplate' }
+        & Pick<ScriptTemplate, 'id' | 'script' | 'title'>
+      )>> }
     )>> }
-  )>> }
+  ) }
 );
 
 export type GetProjectQueryVariables = Exact<{
@@ -1689,24 +1692,26 @@ export type ClearExecutionResultsMutationResult = ApolloReactCommon.MutationResu
 export type ClearExecutionResultsMutationOptions = ApolloReactCommon.BaseMutationOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
 export const GetProjectsDocument = gql`
     query GetProjects {
-  projects @client {
-    id
-    updatedAt
-    title
-    contractTemplates {
+  projectList {
+    projects {
       id
-      script
+      updatedAt
       title
-    }
-    transactionTemplates {
-      id
-      script
-      title
-    }
-    scriptTemplates {
-      id
-      script
-      title
+      contractTemplates {
+        id
+        script
+        title
+      }
+      transactionTemplates {
+        id
+        script
+        title
+      }
+      scriptTemplates {
+        id
+        script
+        title
+      }
     }
   }
 }

--- a/src/api/apollo/mutations.ts
+++ b/src/api/apollo/mutations.ts
@@ -326,7 +326,7 @@ export const CREATE_SCRIPT_EXECUTION = gql`
 `;
 
 export const DELETE_PROJECT = gql`
-  mutation DeleteProject($projectId: UUID) {
+  mutation DeleteProject($projectId: UUID!) {
     deleteProject(projectId: $projectId)
   }
 `;

--- a/src/api/apollo/queries.ts
+++ b/src/api/apollo/queries.ts
@@ -2,27 +2,29 @@ import gql from 'graphql-tag';
 
 export const GET_PROJECTS = gql`
   query GetProjects {
-    projects @client {
-      id
-      updatedAt
-      title
-      contractTemplates {
-        id
-        script
-        title
+    projectList {
+      projects {
+          id
+          updatedAt
+          title
+          contractTemplates {
+            id
+            script
+            title
+          }
+          transactionTemplates {
+            id
+            script
+            title
+          }
+          scriptTemplates {
+            id
+            script
+            title
+          }
+        }
       }
-      transactionTemplates {
-        id
-        script
-        title
-      }
-      scriptTemplates {
-        id
-        script
-        title
-      }
-    }
-  }
+    }  
 `;
 
 export const GET_PROJECT = gql`

--- a/src/api/apollo/queries.ts
+++ b/src/api/apollo/queries.ts
@@ -4,6 +4,7 @@ export const GET_PROJECTS = gql`
   query GetProjects {
     projects @client {
       id
+      updatedAt
       title
       contractTemplates {
         id
@@ -31,6 +32,7 @@ export const GET_PROJECT = gql`
       persist
       mutable
       parentId
+      updatedAt
       seed
       title
       description

--- a/src/api/apollo/resolvers.ts
+++ b/src/api/apollo/resolvers.ts
@@ -1,6 +1,6 @@
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import gql from 'graphql-tag';
-import { MockProject } from 'src/types';
+import { ProjectType } from 'src/types';
 import { normalizeInteractionResponse } from 'util/normalize-interaction-response';
 import {
   ClearExecutionResultsMutationVariables,
@@ -55,7 +55,7 @@ const localResolvers = {
       _variables: unknown,
       _context: unknown,
       _info: unknown,
-    ): MockProject[] => {
+    ): ProjectType[] => {
       return [1, 2, 3, 4, 5, 6].map((id: Scalars['UUID']) => {
         return {
           __typename: 'Project',

--- a/src/api/apollo/resolvers.ts
+++ b/src/api/apollo/resolvers.ts
@@ -49,25 +49,6 @@ function getResultTypeFragment(resultType: ResultType) {
 
 const localResolvers = {
   Query: {
-    // Mocked projects query
-    projects: (
-      _parent: unknown,
-      _variables: unknown,
-      _context: unknown,
-      _info: unknown,
-    ): ProjectType[] => {
-      return [1, 2, 3, 4, 5, 6].map((id: Scalars['UUID']) => {
-        return {
-          __typename: 'Project',
-          id,
-          title: 'Untitled Project',
-          contractTemplates: { id: 0, title: 'contract', script: '' },
-          transactionTemplates: { id: 0, title: 'transaction', script: '' },
-          scriptTemplates: { id: 0, title: 'script', script: '' },
-          lastSavedAt: new Date().toISOString(),
-        };
-      });
-    },
     cachedExecutionResults: (
       _root: any,
       _: any,

--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -7,14 +7,14 @@ import ScriptIcon from 'components/Icons/ScriptIcon';
 import TransactionIcon from 'components/Icons/TransactionIcon';
 import { formatDistance } from 'date-fns';
 import React, { useState } from 'react';
-import { MockProject, SXStyles } from 'src/types';
+import { ProjectType, SXStyles } from 'src/types';
 import { Box, Flex } from 'theme-ui';
 import paths from '../../paths';
 import { useProject } from 'providers/Project/projectHooks';
 import InformationalPopup from 'components/InformationalPopup';
 
 type Props = {
-  project: MockProject;
+  project: ProjectType;
   projectCount: number;
 };
 

--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -95,7 +95,7 @@ const ProjectListItem = ({ project, projectCount }: Props) => {
       icon: DeleteIcon,
     },
   ];
-  const timeAgo = formatDistance(new Date(project.lastSavedAt), new Date(), {
+  const timeAgo = formatDistance(new Date(project.updatedAt), new Date(), {
     addSuffix: true,
   });
 
@@ -151,7 +151,7 @@ const ProjectListItem = ({ project, projectCount }: Props) => {
 
       <Box
         sx={styles.lastSaved}
-        title={new Date(project.lastSavedAt).toISOString()}
+        title={new Date(project.updatedAt).toISOString()}
       >
         Last saved {timeAgo}
       </Box>

--- a/src/components/LeftSidebar/ProjectsList.tsx
+++ b/src/components/LeftSidebar/ProjectsList.tsx
@@ -16,10 +16,7 @@ const styles: SXStyles = {
 };
 
 const ProjectsList = () => {
-  const { projects, loading, error, reload } = useProjects();
-
-  console.log('reloading ....')
-  reload();
+  const { projects, loading, error } = useProjects();
 
   if (loading || !!error) return null;
 

--- a/src/components/LeftSidebar/ProjectsList.tsx
+++ b/src/components/LeftSidebar/ProjectsList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MockProject, SXStyles } from 'src/types';
+import { ProjectType, SXStyles } from 'src/types';
 import { Flex } from 'theme-ui';
 import useProjects from '../../hooks/useProjects';
 import LeftSidebarSection from './LeftSidebarSection';
@@ -16,7 +16,10 @@ const styles: SXStyles = {
 };
 
 const ProjectsList = () => {
-  const { projects, loading, error } = useProjects();
+  const { projects, loading, error, reload } = useProjects();
+
+  console.log('reloading ....')
+  reload();
 
   if (loading || !!error) return null;
 
@@ -25,7 +28,7 @@ const ProjectsList = () => {
       <LeftSidebarSection title="Projects">
         {projects.length === 0 && '0 Projects'}
         <Flex sx={styles.items}>
-          {projects.map((project: MockProject) => (
+          {projects.map((project: ProjectType) => (
             <ProjectListItem
               project={project}
               key={project.id}

--- a/src/components/LeftSidebar/index.tsx
+++ b/src/components/LeftSidebar/index.tsx
@@ -19,7 +19,7 @@ const LeftSidebar = () => {
         <NewProjectButton
           label="Create New Project"
           size="md"
-          variant="secondary"
+          variant="primary"
           delayTooltipShow={300} // Wait for sidebar animation to complete
         />
       </Box>

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@apollo/react-hooks';
 import { GET_PROJECTS } from 'api/apollo/queries';
-import { ProjectType } from 'src/types';
+import { ProjectListType } from 'src/types';
 
 export default function useProjects() {
-  const { loading, error, data } = useQuery<{ projects: ProjectType[] }>(
-    GET_PROJECTS, { fetchPolicy: 'no-cache' },
+  const { loading, error, data } = useQuery<{ projectList: ProjectListType }>(
+    GET_PROJECTS,
   );
 
-  const projects = data?.projects || [];
+  const projects = data?.projectList?.projects || [];
 
   return {
     projects,

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -3,20 +3,9 @@ import { GET_PROJECTS } from 'api/apollo/queries';
 import { ProjectType } from 'src/types';
 
 export default function useProjects() {
-
-  const reload = async () => {
-    const { loading, error, data } = useQuery<{ projects: ProjectType[] }>(
-      GET_PROJECTS, { fetchPolicy: 'network-only' },
-    );
-    console.log('loading', loading, error, data)      
-  }
-
-  console.log('calling get projects', GET_PROJECTS)
   const { loading, error, data } = useQuery<{ projects: ProjectType[] }>(
-    GET_PROJECTS, { fetchPolicy: 'network-only' },
+    GET_PROJECTS, { fetchPolicy: 'no-cache' },
   );
-
-  console.log('projects', loading, error, data, )
 
   const projects = data?.projects || [];
 
@@ -24,6 +13,5 @@ export default function useProjects() {
     projects,
     loading,
     error,
-    reload,
   };
 }

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,11 +1,22 @@
 import { useQuery } from '@apollo/react-hooks';
 import { GET_PROJECTS } from 'api/apollo/queries';
-import { MockProject } from 'src/types';
+import { ProjectType } from 'src/types';
 
 export default function useProjects() {
-  const { loading, error, data } = useQuery<{ projects: MockProject[] }>(
-    GET_PROJECTS,
+
+  const reload = async () => {
+    const { loading, error, data } = useQuery<{ projects: ProjectType[] }>(
+      GET_PROJECTS, { fetchPolicy: 'network-only' },
+    );
+    console.log('loading', loading, error, data)      
+  }
+
+  console.log('calling get projects', GET_PROJECTS)
+  const { loading, error, data } = useQuery<{ projects: ProjectType[] }>(
+    GET_PROJECTS, { fetchPolicy: 'network-only' },
   );
+
+  console.log('projects', loading, error, data, )
 
   const projects = data?.projects || [];
 
@@ -13,5 +24,6 @@ export default function useProjects() {
     projects,
     loading,
     error,
+    reload,
   };
 }

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -63,7 +63,6 @@ export default function useGetProject(
 } {
   const isNewProject = projectId == null;
 
-  console.log('GET_PROJECT, useGetProject', GET_PROJECT)
   const { loading, data: remoteData } = useQuery(GET_PROJECT, {
     variables: { projectId: projectId },
     // skip remote query if this is a new project

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -63,6 +63,7 @@ export default function useGetProject(
 } {
   const isNewProject = projectId == null;
 
+  console.log('GET_PROJECT, useGetProject', GET_PROJECT)
   const { loading, data: remoteData } = useQuery(GET_PROJECT, {
     variables: { projectId: projectId },
     // skip remote query if this is a new project

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface ChildPropsOptional {
 
 export type SXStyles = Record<string, ThemeUICSSObject>;
 
-export type MockProject = {
+export type ProjectType = {
   id: Scalars['UUID'];
   title: string;
   contractTemplates: Template;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,13 +11,17 @@ export interface ChildPropsOptional {
 
 export type SXStyles = Record<string, ThemeUICSSObject>;
 
+export type ProjectListType = {
+    projects: ProjectType[];
+}
+
 export type ProjectType = {
   id: Scalars['UUID'];
   title: string;
   contractTemplates: Template;
   transactionTemplates: Template;
   scriptTemplates: Template;
-  lastSavedAt: string;
+  updatedAt: string;
 };
 
 export type Template = {


### PR DESCRIPTION
Closes: #427 

## Description

 * remove local resolver for get projects. 
 * pull in updatedAt in project query, it's used in project card in project list.
 * regenerated graphQL query code.
 
 
![2022-11-16 16 51 02](https://user-images.githubusercontent.com/3970376/202311627-6808e301-b08c-4359-9833-338cae15fa3c.gif)

 
 
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

