### PR TITLE
auto close project list sidebar when project url changes

### DIFF
--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -26,7 +26,6 @@ export const SaveButton = () => {
   const isSaved = project?.persist;
 
   const saveClicked = () => {
-    console.log('save project');
     Mixpanel.track('Save project clicked', { projectId });
     updateProject(project.title, project.description, project.readme);
   };

--- a/src/containers/Playground/components.tsx
+++ b/src/containers/Playground/components.tsx
@@ -141,7 +141,7 @@ const EditorContainer = ({
     }
   }, [project]);
 
-  const updateProject = (
+  const setProjectProperties = (
     title: string,
     description: string,
     readme: string,
@@ -185,7 +185,11 @@ const EditorContainer = ({
                   placeholder={PLACEHOLDER_TITLE}
                   onChange={(event) => {
                     setTitle(event.target.value);
-                    updateProject(event.target.value, description, readme);
+                    setProjectProperties(
+                      event.target.value,
+                      description,
+                      readme,
+                    );
                   }}
                 />
               </InputBlock>
@@ -196,7 +200,7 @@ const EditorContainer = ({
                   placeholder={PLACEHOLDER_DESCRIPTION}
                   onChange={(event) => {
                     setDescription(event.target.value);
-                    updateProject(title, event.target.value, readme);
+                    setProjectProperties(title, event.target.value, readme);
                   }}
                 />
               </InputBlock>
@@ -208,7 +212,7 @@ const EditorContainer = ({
                   setDescriptionOverflow(overflow);
                   setReadme(readme);
                   if (!overflow) {
-                    updateProject(title, description, readme);
+                    setProjectProperties(title, description, readme);
                   }
                 }}
                 overflow={descriptionOverflow}

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -2,7 +2,7 @@ import { useApolloClient, useQuery } from '@apollo/react-hooks';
 import { navigate, Redirect, useLocation } from '@reach/router';
 import { Account, Project } from 'api/apollo/generated/graphql';
 import { GET_ACTIVE_PROJECT } from 'api/apollo/queries';
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import { ChildProps } from 'src/types';
 import { getParams } from 'util/url';
 import { createDefaultProject } from './projectDefault';
@@ -131,6 +131,13 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [lastSigners, setLastSigners] = useState(null);
   const [showProjectsSidebar, setShowProjectsSidebar] = useState(false);
   const [showBottomPanel, setShowBottomPanel] = useState(false);
+
+  useEffect(() => {
+    if (showProjectsSidebar) {
+      // close project sidebar if open and a different project gets loaded.
+      setShowProjectsSidebar(false);
+    }
+  }, [projectId]);
 
   const [selectedResourceAccount, setSelectedResourceAccount] = useState<
     string | null


### PR DESCRIPTION
Closes: #448 

## Description

auto close project list when user selects another project.
simple name change "updateProject" has a different meaning, so changed helper method to clarify the code.

![2022-11-21 14 56 43](https://user-images.githubusercontent.com/3970376/203156731-ab5c8b77-9bcc-43e0-8d27-35f7b02e9341.gif)




______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

