### PR TITLE
fixed project name updating

### DIFF
--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -112,29 +112,7 @@ const styles: SXStyles = {
     borderRadius: '8px',
     color: '#3031D1',
   },
-  input: {
-    width: '100%',
-    fontSize: '15px',
-    color: '#69717E',
-    fontWeight: '450',
-    textOverflow: 'ellipsis',
-    border: '1px solid #dedede',
-    pointerEvents: 'initial',
-    background: '#FFFFFF',
-    fontFamily: 'inherit',
-    borderRadius: '4px',
-  },
-  inputReadOnly: {
-    width: '100%',
-    fontSize: '15px',
-    color: 'inherit',
-    fontWeight: '450',
-    textOverflow: 'ellipsis',
-    border: '1px solid transparent',
-    background: 'none',
-    pointerEvents: 'none',
-    fontFamily: 'inherit',
-  },
+
 };
 
 type MenuListProps = {
@@ -147,8 +125,6 @@ type MenuListProps = {
   onDelete: any;
 };
 
-const NAME_MAX_CHARS = 50;
-
 const MenuList: React.FC<MenuListProps> = ({
   title,
   itemType,
@@ -159,10 +135,8 @@ const MenuList: React.FC<MenuListProps> = ({
   onDelete,
 }) => {
   const { active } = useProject();
-  const isEditing = createRef<HTMLInputElement>();
   const [editing, setEditing] = useState([]);
-  const enterPressed = useKeyPress('Enter');
-  const escapePressed = useKeyPress('Escape');
+  const [itemNames, setItemNames] = useState(items.map(item => {return item.title}));
   const [isInserting, setIsInserting] = useState(false);
   const [isFileShuttered, setIsFileShuttered] = useState(false);
 
@@ -181,12 +155,13 @@ const MenuList: React.FC<MenuListProps> = ({
     return setEditing([...editing, i]);
   };
 
-  useEffect(() => {
-    if (enterPressed || escapePressed) {
-      setEditing([]);
-      isEditing.current?.blur();
+  const setItemName = (name: string, index: number) => {
+    if (itemNames.indexOf(index)) {
+      let _newNames = [...itemNames];
+      _newNames.splice(index, 1, name);
+      setItemNames(_newNames);
     }
-  }, [enterPressed, escapePressed]);
+  }
 
   const getIcon = (title: string) => {
     switch (title) {
@@ -255,10 +230,7 @@ const MenuList: React.FC<MenuListProps> = ({
               i === 0;
             const isActive =
               isDefault || (active.type === itemType && item.id === params.id);
-            const dataTest = `sidebar-${item.title}`;
-            const inputStyles = editing.includes(i)
-              ? styles.input
-              : styles.inputReadOnly;
+            
             const submenuOptions = [
               {
                 name: 'Edit name',
@@ -277,7 +249,6 @@ const MenuList: React.FC<MenuListProps> = ({
                 sx={isActive ? styles.selectedItem : styles.item}
                 title={item.title}
                 key={item.id}
-                data-test={dataTest}
               >
                 <Flex
                   sx={{ alignItems: 'center' }}
@@ -294,32 +265,16 @@ const MenuList: React.FC<MenuListProps> = ({
                   {/* NOTE: Optimize this to a controlled input! */}
                   <Input
                     editing={editing}
-                    sx={inputStyles}
                     type="text"
-                    defaultValue={item.title}
-                    title={item.title}
+                    value={itemNames[i]}
                     index={i}
                     toggleEditing={toggleEditing}
                     onChange={(e: any) => {
-                      if (e.target.value.length > NAME_MAX_CHARS) {
-                        isEditing.current.value = e.target.value.substr(
-                          0,
-                          NAME_MAX_CHARS - 1,
-                        );
-                      }
+                      setItemName(e.target.value, i)
                     }}
                   />
                 </Flex>
                 <ContextMenu options={submenuOptions} showEllipsis={isActive} />
-
-                {/* TODO: Delete file, Update Filename userflows
-                {!editing.includes(i) && isActive && items.length > 1 && (
-                  <Box
-                    onClick={}
-                  >
-                    <FaTimes />
-                  </Box>
-                )} */}
               </Flex>
             );
           })}

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -112,7 +112,6 @@ const styles: SXStyles = {
     borderRadius: '8px',
     color: '#3031D1',
   },
-
 };
 
 type MenuListProps = {
@@ -136,7 +135,11 @@ const MenuList: React.FC<MenuListProps> = ({
 }) => {
   const { active } = useProject();
   const [editing, setEditing] = useState([]);
-  const [itemNames, setItemNames] = useState(items.map(item => {return item.title}));
+  const [itemNames, setItemNames] = useState(
+    items.map((item) => {
+      return item.title;
+    }),
+  );
   const [isInserting, setIsInserting] = useState(false);
   const [isFileShuttered, setIsFileShuttered] = useState(false);
 
@@ -161,7 +164,7 @@ const MenuList: React.FC<MenuListProps> = ({
       _newNames.splice(index, 1, name);
       setItemNames(_newNames);
     }
-  }
+  };
 
   const getIcon = (title: string) => {
     switch (title) {
@@ -230,7 +233,7 @@ const MenuList: React.FC<MenuListProps> = ({
               i === 0;
             const isActive =
               isDefault || (active.type === itemType && item.id === params.id);
-            
+
             const submenuOptions = [
               {
                 name: 'Edit name',
@@ -270,7 +273,7 @@ const MenuList: React.FC<MenuListProps> = ({
                     index={i}
                     toggleEditing={toggleEditing}
                     onChange={(e: any) => {
-                      setItemName(e.target.value, i)
+                      setItemName(e.target.value, i);
                     }}
                   />
                 </Flex>

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -9,11 +9,10 @@ import ExplorerTransactionIcon from 'components/Icons/ExplorerTransactionIcon';
 import Input from 'components/ExplorerInput';
 import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
-import React, { createRef, SyntheticEvent, useEffect, useState } from 'react';
+import React, { SyntheticEvent, useState } from 'react';
 import { SXStyles } from 'src/types';
 import { Box, Flex } from 'theme-ui';
 import { getParams } from 'util/url';
-import useKeyPress from '../../../hooks/useKeyPress';
 import { ContextMenu } from '../../ContextMenu';
 
 const styles: SXStyles = {

--- a/src/components/ExplorerInput.tsx
+++ b/src/components/ExplorerInput.tsx
@@ -1,48 +1,68 @@
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
-import { Input as ThemeUiInput, ThemeUICSSObject } from 'theme-ui';
+import { SXStyles } from 'src/types';
+import { Input as ThemeUiInput } from 'theme-ui';
 
 interface InputProps {
   onClick?: () => void;
-  onBlur?: (event: any) => void;
   onChange?: (event: ChangeEvent) => void;
-  readOnly?: boolean;
-  defaultValue: string;
-  sx?: ThemeUICSSObject;
+  value: string;
   type: string;
-  'data-test'?: string;
-  title?: string;
   index: number;
   editing: Array<number>;
   toggleEditing: any;
 }
 
+const styles: SXStyles = {
+  input: {
+    width: '100%',
+    fontSize: '15px',
+    color: '#69717E',
+    fontWeight: '450',
+    textOverflow: 'ellipsis',
+    border: '1px solid #dedede',
+    pointerEvents: 'initial',
+    background: '#FFFFFF',
+    fontFamily: 'inherit',
+    borderRadius: '4px',
+  },
+  inputReadOnly: {
+    width: '100%',
+    fontSize: '15px',
+    color: 'inherit',
+    fontWeight: '450',
+    textOverflow: 'ellipsis',
+    border: '1px solid transparent',
+    background: 'none',
+    pointerEvents: 'none',
+    fontFamily: 'inherit',
+  },
+}
+
 const Input = ({
   onClick,
-  sx = {},
-  'data-test': dataTest,
   type,
-  onBlur,
   onChange,
-  readOnly,
-  defaultValue,
+  value,
   index,
-  title,
   editing,
   toggleEditing,
 }: InputProps) => {
   const ref = useRef(null);
   const [isEditing, setIsEditing] = useState(false);
+  const isEditingParent = editing.includes(index);
+  const inputStyle = isEditingParent ? styles.input : styles.inputReadOnly;
+  const MAX_LENGTH = 50;
 
   useEffect(() => {
     const handleClickOutside = (event: any) => {
       if (ref.current && !ref.current.contains(event.target)) {
         document.removeEventListener('click', handleClickOutside, true);
-        toggleEditing(index, title);
+        toggleEditing(index, ref.current.value);
         setIsEditing(false);
       }
       return;
     };
-    if (editing.includes(index) && !isEditing) {
+    if (isEditingParent && !isEditing) {
       document.addEventListener('click', handleClickOutside, true);
       setIsEditing(true);
     }
@@ -54,15 +74,14 @@ const Input = ({
 
   return (
     <ThemeUiInput
-      sx={sx}
+      sx={inputStyle}
       ref={ref}
       onClick={onClick}
       type={type}
-      onBlur={onBlur}
       onChange={onChange}
-      readOnly={readOnly}
-      defaultValue={defaultValue}
-      data-test={dataTest}
+      readOnly={!isEditingParent && !isEditing}
+      value={value}
+      maxLength={MAX_LENGTH}
     />
   );
 };

--- a/src/components/ExplorerInput.tsx
+++ b/src/components/ExplorerInput.tsx
@@ -36,7 +36,7 @@ const styles: SXStyles = {
     pointerEvents: 'none',
     fontFamily: 'inherit',
   },
-}
+};
 
 const Input = ({
   onClick,

--- a/src/components/TopNav/NavInput.tsx
+++ b/src/components/TopNav/NavInput.tsx
@@ -4,7 +4,7 @@ import { Input as ThemeUiInput } from 'theme-ui';
 
 interface NavInputProps {
   onChange?: (event: ChangeEvent) => void;
-  value: string
+  value: string;
   type: string;
   updateValue: any;
 }
@@ -36,14 +36,9 @@ const styles: SXStyles = {
     textAlign: 'center',
     borderRadius: '0px',
   },
-}
+};
 
-const NavInput = ({
-  onChange,
-  value,
-  type,
-  updateValue,
-}: NavInputProps) => {
+const NavInput = ({ onChange, value, type, updateValue }: NavInputProps) => {
   const ref = useRef(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const inputStyle = isEditing ? styles.input : styles.inputReadOnly;
@@ -51,9 +46,9 @@ const NavInput = ({
 
   const openEditing = () => {
     if (!isEditing) {
-      setIsEditing(!isEditing)
+      setIsEditing(!isEditing);
     }
-  }
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: any) => {
@@ -67,9 +62,8 @@ const NavInput = ({
     if (isEditing) {
       document.addEventListener('click', handleClickOutside, true);
     }
-    return
+    return;
   }, [isEditing]);
-
 
   return (
     <ThemeUiInput

--- a/src/components/TopNav/NavInput.tsx
+++ b/src/components/TopNav/NavInput.tsx
@@ -55,8 +55,6 @@ const NavInput = ({
     }
   }
 
-  // clean up editing calls
-  // do the same for the menu inputs
   useEffect(() => {
     const handleClickOutside = (event: any) => {
       const clicked = !ref.current.contains(event.target);

--- a/src/components/TopNav/NavInput.tsx
+++ b/src/components/TopNav/NavInput.tsx
@@ -1,58 +1,88 @@
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
-import { Input as ThemeUiInput, ThemeUICSSObject } from 'theme-ui';
+import { SXStyles } from 'src/types';
+import { Input as ThemeUiInput } from 'theme-ui';
 
 interface NavInputProps {
   onChange?: (event: ChangeEvent) => void;
-  defaultValue: string;
   value: string
-  sx?: ThemeUICSSObject;
   type: string;
-  'data-test'?: string;
-  editing: boolean;
-  setTopNavEditing: any;
-  updateProjectName: any;
+  updateValue: any;
+}
+
+const styles: SXStyles = {
+  input: {
+    width: '100%',
+    fontSize: '15px',
+    color: '#000000',
+    fontWeight: '450',
+    textOverflow: 'ellipsis',
+    border: 'none',
+    pointerEvents: 'initial',
+    background: '#DEE2E9',
+    backgroundColor: '#DEE2E9',
+    fontFamily: 'Termina',
+    textAlign: 'center',
+    borderRadius: '0px',
+  },
+  inputReadOnly: {
+    width: '100%',
+    fontSize: '15px',
+    border: 'none',
+    color: 'inherit',
+    fontWeight: '450',
+    textOverflow: 'ellipsis',
+    background: 'none',
+    fontFamily: 'Termina',
+    textAlign: 'center',
+    borderRadius: '0px',
+  },
 }
 
 const NavInput = ({
   onChange,
-  defaultValue,
   value,
-  sx = {},
   type,
-  'data-test': dataTest,
-  editing,
-  setTopNavEditing,
-  updateProjectName,
+  updateValue,
 }: NavInputProps) => {
   const ref = useRef(null);
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const inputStyle = isEditing ? styles.input : styles.inputReadOnly;
+  const MAX_LENGTH = 50;
 
+  const openEditing = () => {
+    if (!isEditing) {
+      setIsEditing(!isEditing)
+    }
+  }
+
+  // clean up editing calls
+  // do the same for the menu inputs
   useEffect(() => {
     const handleClickOutside = (event: any) => {
-      if (ref.current && !ref.current.contains(event.target)) {
-        console.log(event)
-        console.log('saving on outsideclick navinput projectnanme ' + value)
+      const clicked = !ref.current.contains(event.target);
+      if (ref.current && clicked) {
         document.removeEventListener('click', handleClickOutside, true);
-        updateProjectName(value);
-        setTopNavEditing(false);
+        updateValue(ref.current.value);
         setIsEditing(false);
       }
     };
-    if (editing && !isEditing) {
+    if (isEditing) {
       document.addEventListener('click', handleClickOutside, true);
-      setIsEditing(true);
     }
-  }, [editing]);
+    return
+  }, [isEditing]);
+
+
   return (
     <ThemeUiInput
-      sx={sx}
+      onClick={openEditing}
+      sx={inputStyle}
       ref={ref}
+      readOnly={!isEditing}
       type={type}
       onChange={onChange}
-      readOnly={editing}
       value={value}
-      defaultValue={defaultValue}
-      data-test={dataTest}
+      maxLength={MAX_LENGTH}
     />
   );
 };

--- a/src/components/TopNav/NavInput.tsx
+++ b/src/components/TopNav/NavInput.tsx
@@ -4,22 +4,24 @@ import { Input as ThemeUiInput, ThemeUICSSObject } from 'theme-ui';
 interface NavInputProps {
   onChange?: (event: ChangeEvent) => void;
   defaultValue: string;
+  value: string
   sx?: ThemeUICSSObject;
   type: string;
   'data-test'?: string;
   editing: boolean;
-  toggleEditing: any;
+  setTopNavEditing: any;
   updateProjectName: any;
 }
 
 const NavInput = ({
   onChange,
   defaultValue,
+  value,
   sx = {},
   type,
   'data-test': dataTest,
   editing,
-  toggleEditing,
+  setTopNavEditing,
   updateProjectName,
 }: NavInputProps) => {
   const ref = useRef(null);
@@ -28,9 +30,11 @@ const NavInput = ({
   useEffect(() => {
     const handleClickOutside = (event: any) => {
       if (ref.current && !ref.current.contains(event.target)) {
+        console.log(event)
+        console.log(value)
         document.removeEventListener('click', handleClickOutside, true);
-        updateProjectName();
-        toggleEditing();
+        updateProjectName(value);
+        setTopNavEditing(false);
         setIsEditing(false);
       }
     };
@@ -38,12 +42,7 @@ const NavInput = ({
       document.addEventListener('click', handleClickOutside, true);
       setIsEditing(true);
     }
-    return () => {
-      document.removeEventListener('click', handleClickOutside, true);
-      setIsEditing(false);
-    };
   }, [editing]);
-
   return (
     <ThemeUiInput
       sx={sx}
@@ -51,6 +50,7 @@ const NavInput = ({
       type={type}
       onChange={onChange}
       readOnly={editing}
+      value={value}
       defaultValue={defaultValue}
       data-test={dataTest}
     />

--- a/src/components/TopNav/NavInput.tsx
+++ b/src/components/TopNav/NavInput.tsx
@@ -31,7 +31,7 @@ const NavInput = ({
     const handleClickOutside = (event: any) => {
       if (ref.current && !ref.current.contains(event.target)) {
         console.log(event)
-        console.log(value)
+        console.log('saving on outsideclick navinput projectnanme ' + value)
         document.removeEventListener('click', handleClickOutside, true);
         updateProjectName(value);
         setTopNavEditing(false);

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -64,11 +64,11 @@ const TopNav = () => {
 
   const updateProjectName = (name: string) => {
     updateProject(name, project.description, project.readme);
-  }
+  };
 
   useEffect(() => {
     setProjectName(project.title);
-  }, [project?.id])
+  }, [project?.id]);
 
   return (
     <Flex sx={styles.root}>
@@ -84,7 +84,7 @@ const TopNav = () => {
         </Button>
         <NewProjectButton size="sm" variant="secondaryLegacy" inline={true} />
       </Flex>
-      <Flex sx={styles.topNavProjectName} >
+      <Flex sx={styles.topNavProjectName}>
         <NavInput
           type="text"
           value={projectName}

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -44,43 +44,14 @@ const styles: SXStyles = {
   topNavSectionRight: {
     flexDirection: 'row-reverse',
   },
-  input: {
-    width: '100%',
-    fontSize: '15px',
-    color: '#000000',
-    fontWeight: '450',
-    textOverflow: 'ellipsis',
-    border: 'none',
-    pointerEvents: 'initial',
-    background: '#DEE2E9',
-    backgroundColor: '#DEE2E9',
-    fontFamily: 'Termina',
-    textAlign: 'center',
-    borderRadius: '0px',
-  },
-  inputReadOnly: {
-    width: '100%',
-    fontSize: '15px',
-    border: 'none',
-    color: 'inherit',
-    fontWeight: '450',
-    textOverflow: 'ellipsis',
-    background: 'none',
-    pointerEvents: 'none',
-    fontFamily: 'Termina',
-    textAlign: 'center',
-    borderRadius: '0px',
-  },
 };
 
 const TopNav = () => {
-  const defaultProjectName = 'Untitled Project';
   const { project, updateProject, toggleProjectsSidebar } = useProject();
   const [showExport, setShowExport] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
-  const [editing, setEditing] = useState(false);
   const [projectName, setProjectName] = useState(project.title);
-  const inputStyles = editing ? styles.input : styles.inputReadOnly;
+  const MAX_CHARS = 50;
 
   const onStartButtonClick = () => {
     setShowExamples(true);
@@ -89,21 +60,13 @@ const TopNav = () => {
 
   const onNameInputChange = (name: string) => {
     setProjectName(name);
-    console.log('setting onChange ' + name)
-  };
-
-  const toggleEditing = () => {
-    const toggledEditing = !editing;
-    return setEditing(toggledEditing);
   };
 
   const updateProjectName = (name: string) => {
     updateProject(name, project.description, project.readme);
-    setEditing(false);
   }
 
   useEffect(() => {
-    console.log('useEffect' + project.title)
     setProjectName(project.title);
   }, [project?.id])
 
@@ -121,18 +84,21 @@ const TopNav = () => {
         </Button>
         <NewProjectButton size="sm" variant="secondaryLegacy" inline={true} />
       </Flex>
-      <Flex sx={styles.topNavProjectName} onClick={() => toggleEditing()}>
+      <Flex sx={styles.topNavProjectName} >
         <NavInput
-          editing={editing}
-          sx={inputStyles}
           type="text"
           value={projectName}
-          defaultValue={defaultProjectName}
-          setTopNavEditing={setEditing}
           onChange={(e: any) => {
+            if (e.target.value.length > MAX_CHARS){
+              e.target.value = e.target.value.substr(
+                0,
+                MAX_CHARS - 1,
+              );
+            }
+            console.log(e.target.value)
             onNameInputChange(e.target.value);
           }}
-          updateProjectName={updateProjectName}
+          updateValue={updateProjectName}
         />
         {/* <ThemeUIButton variant="secondaryLegacy" onClick={onStartButtonClick}>
           <AnimatedText>Click here to start a tutorial</AnimatedText>

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -89,7 +89,7 @@ const TopNav = () => {
 
   const onNameInputChange = (name: string) => {
     setProjectName(name);
-    console.log(name)
+    console.log('setting onChange ' + name)
   };
 
   const toggleEditing = () => {

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -6,7 +6,6 @@ import NavInput from './NavInput';
 import NewProjectButton from 'components/NewProjectButton';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useEffect, useState } from 'react';
-import useKeyPress from '../../hooks/useKeyPress';
 import { SXStyles } from 'src/types';
 import { Flex } from 'theme-ui';
 import Mixpanel from 'util/mixpanel';
@@ -80,9 +79,7 @@ const TopNav = () => {
   const [showExport, setShowExport] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
   const [editing, setEditing] = useState(false);
-  const [projectName, setProjectName] = useState(defaultProjectName);
-  const enterPressed = useKeyPress('Enter');
-  const escapePressed = useKeyPress('Escape');
+  const [projectName, setProjectName] = useState(project.title);
   const inputStyles = editing ? styles.input : styles.inputReadOnly;
 
   const onStartButtonClick = () => {
@@ -92,6 +89,7 @@ const TopNav = () => {
 
   const onNameInputChange = (name: string) => {
     setProjectName(name);
+    console.log(name)
   };
 
   const toggleEditing = () => {
@@ -99,12 +97,15 @@ const TopNav = () => {
     return setEditing(toggledEditing);
   };
 
+  const updateProjectName = (name: string) => {
+    updateProject(name, project.description, project.readme);
+    setEditing(false);
+  }
+
   useEffect(() => {
-    if (enterPressed || escapePressed) {
-      updateProject(projectName, project.description, project.readme);
-      setEditing(false);
-    }
-  }, [enterPressed, escapePressed]);
+    console.log('useEffect' + project.title)
+    setProjectName(project.title);
+  }, [project?.id])
 
   return (
     <Flex sx={styles.root}>
@@ -125,12 +126,13 @@ const TopNav = () => {
           editing={editing}
           sx={inputStyles}
           type="text"
+          value={projectName}
           defaultValue={defaultProjectName}
-          toggleEditing={toggleEditing}
+          setTopNavEditing={setEditing}
           onChange={(e: any) => {
             onNameInputChange(e.target.value);
           }}
-          updateProjectName={updateProject}
+          updateProjectName={updateProjectName}
         />
         {/* <ThemeUIButton variant="secondaryLegacy" onClick={onStartButtonClick}>
           <AnimatedText>Click here to start a tutorial</AnimatedText>

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -89,13 +89,6 @@ const TopNav = () => {
           type="text"
           value={projectName}
           onChange={(e: any) => {
-            if (e.target.value.length > MAX_CHARS){
-              e.target.value = e.target.value.substr(
-                0,
-                MAX_CHARS - 1,
-              );
-            }
-            console.log(e.target.value)
             onNameInputChange(e.target.value);
           }}
           updateValue={updateProjectName}

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -51,7 +51,6 @@ const TopNav = () => {
   const [showExport, setShowExport] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
   const [projectName, setProjectName] = useState(project.title);
-  const MAX_CHARS = 50;
 
   const onStartButtonClick = () => {
     setShowExamples(true);

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -188,11 +188,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     try {
-      res = await mutator.saveProject(
-        title,
-        description,
-        readme,
-      );
+      res = await mutator.saveProject(title, description, readme);
     } catch (e) {
       console.error(e);
       setIsSaving(false);

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -189,7 +189,6 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     let res;
     try {
       res = await mutator.saveProject(
-        project.transactionTemplates[active.index].id,
         title,
         description,
         readme,

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -175,7 +175,7 @@ export default class ProjectMutator {
       Mixpanel.track('Project saved', { projectId: this.projectId });
     }
 
-    navigate(`/${this.projectId}`, { replace: true });
+    // navigate(`/${this.projectId}`, { replace: true });
   }
 
   // TODO: This is a temporary function used to set persist: true after creating a blank project.

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -133,7 +133,6 @@ export default class ProjectMutator {
   }
 
   async saveProject(
-    isFork: boolean,
     title: string,
     description: string,
     readme: string,
@@ -169,11 +168,8 @@ export default class ProjectMutator {
       },
     });
 
-    if (isFork) {
-      Mixpanel.track('Project forked', { projectId: this.projectId });
-    } else {
-      Mixpanel.track('Project saved', { projectId: this.projectId });
-    }
+    Mixpanel.track('Project saved', { projectId: this.projectId });
+
 
   }
 

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -1,5 +1,3 @@
-import { navigate } from '@reach/router';
-
 import ApolloClient from 'apollo-client';
 
 import {

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -175,7 +175,6 @@ export default class ProjectMutator {
       Mixpanel.track('Project saved', { projectId: this.projectId });
     }
 
-    // navigate(`/${this.projectId}`, { replace: true });
   }
 
   // TODO: This is a temporary function used to set persist: true after creating a blank project.

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -132,11 +132,7 @@ export default class ProjectMutator {
     return project;
   }
 
-  async saveProject(
-    title: string,
-    description: string,
-    readme: string,
-  ) {
+  async saveProject(title: string, description: string, readme: string) {
     if (this.isLocal) {
       await this.createProject();
       unregisterOnCloseSaveMessage();
@@ -169,8 +165,6 @@ export default class ProjectMutator {
     });
 
     Mixpanel.track('Project saved', { projectId: this.projectId });
-
-
   }
 
   // TODO: This is a temporary function used to set persist: true after creating a blank project.


### PR DESCRIPTION
Closes: #440 

## Description

- fixed project name to update when new project is selected
- fixed click outsideclick CTA for navinputs to save project name
- refactored menulist inputs to match navinput fixes]
- removed isFork from saveProject mutation (mutation no longer checks for forked projects)

NavInput
<img width="378" alt="image" src="https://user-images.githubusercontent.com/23225108/203469186-56590361-47a7-4148-8aec-33cea2cd2a23.png">

navinput selected
<img width="403" alt="image" src="https://user-images.githubusercontent.com/23225108/203469214-70fbd4a5-0200-441f-9de2-ba601944d87b.png">

menulist input
<img width="224" alt="image" src="https://user-images.githubusercontent.com/23225108/203469283-8a6b1eec-82ed-4136-a7ea-312d0477f0a3.png">

menulist input selected
<img width="380" alt="image" src="https://user-images.githubusercontent.com/23225108/203469263-da873097-623e-4c5d-8c4e-d359a28fcf96.png">

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

