### PR TITLE
update project data after project changes

### DIFF
--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -20,9 +20,7 @@ export const SaveButton = () => {
       ? null
       : window.location.pathname.slice(1);
 
-  const { project, updateProject } = useProject();
-
-  // todo: verify Project persist is true when project is saved.
+  const { project, isSaving, updateProject } = useProject();
   const isSaved = project?.persist;
 
   const saveClicked = () => {
@@ -48,7 +46,7 @@ export const SaveButton = () => {
           variant="alternate"
           size="sm"
           inline={true}
-          disabled={isSaved}
+          disabled={isSaved || isSaving}
         >
           {buttonLabel}
         </Button>

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -156,6 +156,9 @@ export default class ProjectMutator {
         description,
         readme,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         debounceKey: key,
         serializationKey: PROJECT_SERIALIZATION_KEY,
@@ -232,6 +235,9 @@ export default class ProjectMutator {
         script,
         title,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         debounceKey: key,
         serializationKey: PROJECT_SERIALIZATION_KEY,
@@ -289,6 +295,9 @@ export default class ProjectMutator {
         script,
         title,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -347,6 +356,9 @@ export default class ProjectMutator {
         script: script,
         title: title,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         debounceKey: key,
         serializationKey: PROJECT_SERIALIZATION_KEY,
@@ -366,6 +378,9 @@ export default class ProjectMutator {
         projectId: this.projectId,
         templateId,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -403,6 +418,9 @@ export default class ProjectMutator {
         projectId: this.projectId,
         templateId,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -441,6 +459,9 @@ export default class ProjectMutator {
         script,
         arguments: args,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -465,6 +486,9 @@ export default class ProjectMutator {
         script,
         title,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -519,6 +543,9 @@ export default class ProjectMutator {
         script,
         title,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -584,6 +611,9 @@ export default class ProjectMutator {
         index,
         projectId: this.projectId,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         debounceKey: key,
         serializationKey: PROJECT_SERIALIZATION_KEY,
@@ -612,6 +642,9 @@ export default class ProjectMutator {
         script: contractTemplate.script,
         signer: account.address,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },
@@ -640,6 +673,9 @@ export default class ProjectMutator {
         projectId: this.projectId,
         templateId,
       },
+      refetchQueries: [
+        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+      ],
       context: {
         serializationKey: PROJECT_SERIALIZATION_KEY,
       },


### PR DESCRIPTION
Closes: #385 

## Description

Now that `updatedAt` property gets updated after any change, need to fetch it after anything has changed in the project.
future ticket will be to reorganize cache to update `updatedAt` for any change.
perf improvement:
https://github.com/onflow/flow-playground/issues/477
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

