### PR TITLE
implemented account storage view

### DIFF
--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -393,6 +393,10 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     validate(list, values);
   }, [list, values]);
 
+  if (type === EntityType.AccountStorage) {
+    return null;
+  }
+
   // ===========================================================================
   // RENDER
   return (

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -231,6 +231,7 @@ const MenuList: React.FC<MenuListProps> = ({
           {items.map((item, i) => {
             const isDefault =
               params.id === undefined &&
+              params.storage === undefined &&
               itemType === EntityType.ContractTemplate &&
               i === 0;
             const isActive =

--- a/src/components/EditorPanels.tsx
+++ b/src/components/EditorPanels.tsx
@@ -66,7 +66,7 @@ const styles: SXStyles = {
     paddingRight: '4px',
     filter:
       'brightness(0) saturate(100%) invert(14%) sepia(96%) saturate(3637%) hue-rotate(242deg) brightness(95%) contrast(100%)',
-  }
+  },
 };
 
 const EditorPanels = ({ show }: EditorPanelsProps) => {
@@ -92,9 +92,9 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
         (key) => storageMap[key] == active.index,
       );
       fileName =
-      accountNumber == '0x01'
-        ? `${accountNumber}-Default`
-        : `${accountNumber}`;
+        accountNumber == '0x01'
+          ? `${accountNumber}-Default`
+          : `${accountNumber}`;
       script = project.accounts[active.index].state;
   }
 

--- a/src/components/EditorPanels.tsx
+++ b/src/components/EditorPanels.tsx
@@ -1,14 +1,26 @@
 import { Tab } from '@headlessui/react';
 import { Allotment } from 'allotment';
 import 'allotment/dist/style.css';
+import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useState } from 'react';
+import theme from '../theme';
 import { SXStyles } from 'src/types';
 import { Box, Flex } from 'theme-ui';
+import { storageMap } from 'util/accounts';
 import BottomEditorPanel from './BottomEditorPanel';
 import BottomEditorPanelHeader from './BottomEditorPanelHeader';
+import Button from './Button';
 import CadenceEditor from './CadenceEditor';
+import CopyIcon from './Icons/CopyIcon';
+import ExplorerTransactionIcon from './Icons/ExplorerTransactionIcon';
+import ExplorerScriptIcon from './Icons/ExplorerScriptIcon';
+import ExplorerContractIcon from './Icons/ExplorerContractIcon';
+import useClipboard from 'react-use-clipboard';
+import { FaClipboardCheck } from 'react-icons/fa';
+
 export const BOTTOM_EDITOR_PANEL_HEADER_HEIGHT = 70;
+const EDITOR_HEADER_HEIGHT = 70;
 
 type EditorPanelsProps = {
   show: boolean;
@@ -28,16 +40,101 @@ const styles: SXStyles = {
     height: '100%',
     border: '2px solid rgba(48, 49, 209, 0.1)',
   },
+  editorHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: '24px 28px',
+  },
+  copyButton: {
+    width: '32px',
+    height: '32px',
+    padding: '0px',
+    backgroundColor: theme.colors.alternateButtonBackground,
+  },
+  editorTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    fontFamily: 'inherit',
+    justifyContent: 'start',
+    marginLeft: '16px',
+    padding: '0px 8px',
+    background: '#EAEAFA',
+    borderRadius: '8px',
+    color: '#3031D1',
+  },
+  icon: {
+    paddingRight: '4px',
+    filter:
+      'brightness(0) saturate(100%) invert(14%) sepia(96%) saturate(3637%) hue-rotate(242deg) brightness(95%) contrast(100%)',
+  }
 };
 
 const EditorPanels = ({ show }: EditorPanelsProps) => {
-  const { showBottomPanel } = useProject();
+  const { project, active, showBottomPanel } = useProject();
   const [selectedBottomTab, setSelectedBottomTab] = useState(0);
+
+  let fileName, script;
+  switch (active.type) {
+    case EntityType.ContractTemplate:
+      fileName = `${project.contractTemplates[active.index].title}.cdc`;
+      script = project.contractTemplates[active.index].script;
+      break;
+    case EntityType.TransactionTemplate:
+      fileName = `${project.transactionTemplates[active.index].title}.cdc`;
+      script = project.contractTemplates[active.index].script;
+      break;
+    case EntityType.ScriptTemplate:
+      fileName = `${project.scriptTemplates[active.index].title}.cdc`;
+      script = project.contractTemplates[active.index].script;
+      break;
+    default:
+      const accountNumber = Object.keys(storageMap).find(
+        (key) => storageMap[key] == active.index,
+      );
+      fileName =
+      accountNumber == '0x01'
+        ? `${accountNumber}-Default`
+        : `${accountNumber}`;
+      script = project.accounts[active.index].state;
+  }
+
+  const [isCopied, setCopied] = useClipboard(script, {
+    successDuration: 1000,
+  });
+
+  const getIcon = () => {
+    switch (active.type) {
+      case EntityType.TransactionTemplate:
+        return <ExplorerTransactionIcon />;
+      case EntityType.ScriptTemplate:
+        return <ExplorerScriptIcon />;
+      case EntityType.ContractTemplate:
+        return <ExplorerContractIcon />;
+      default:
+        return null;
+    }
+  };
 
   return (
     <Flex sx={styles.root}>
       <Flex sx={styles.editor}>
         <Allotment vertical={true}>
+          <Allotment.Pane minSize={EDITOR_HEADER_HEIGHT}>
+            <Flex sx={styles.editorHeader}>
+              <Flex sx={styles.editorTitle}>
+                <Box sx={styles.icon}>{getIcon()}</Box>
+                {fileName}
+              </Flex>
+
+              <Button
+                sx={styles.copyButton}
+                variant="explorer"
+                onClick={setCopied}
+              >
+                {isCopied ? <FaClipboardCheck /> : <CopyIcon />}
+              </Button>
+            </Flex>
+          </Allotment.Pane>
           <Allotment.Pane minSize={100} preferredSize="100%">
             <CadenceEditor show={show} />
           </Allotment.Pane>

--- a/src/components/RenderResponse/index.tsx
+++ b/src/components/RenderResponse/index.tsx
@@ -49,8 +49,7 @@ export const RenderResponse = () => {
   const resultType = getResultType(active);
   const filteredResults = resultType
     ? data.cachedExecutionResults[resultType]
-    : data.cachedExecutionResults;
-
+    : [];
   return (
     <Flex sx={styles.root} data-test="execution-results">
       {!loading &&

--- a/src/containers/Playground/components.tsx
+++ b/src/containers/Playground/components.tsx
@@ -2,29 +2,29 @@ import styled from '@emotion/styled';
 import { Account, Project } from 'api/apollo/generated/graphql';
 import { motion } from 'framer-motion';
 import { Editor as EditorRoot } from 'layout/Editor';
-import { ActiveEditor, EntityType } from 'providers/Project';
-import {
-  PLACEHOLDER_DESCRIPTION,
-  PLACEHOLDER_TITLE,
-} from 'providers/Project/projectDefault';
+import { ActiveEditor } from 'providers/Project';
+// import {
+//   PLACEHOLDER_DESCRIPTION,
+//   PLACEHOLDER_TITLE,
+// } from 'providers/Project/projectDefault';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useEffect, useRef, useState } from 'react';
-import { Divider, Flex } from 'theme-ui';
+import { Flex } from 'theme-ui';
 
 // import CadenceEditor from 'components/CadenceEditor';
-import {
-  Input,
-  InputBlock,
-  Label,
-} from 'components/Arguments/SingleArgument/styles';
-import { Markdown } from 'components/Markdown';
-import { MdeEditor } from 'components/MdeEditor';
-import {
-  ProjectDescription,
-  ProjectHeading,
-  ProjectInfoContainer,
-  ReadmeHtmlContainer,
-} from './layout-components';
+// import {
+//   Input,
+//   InputBlock,
+//   Label,
+// } from 'components/Arguments/SingleArgument/styles';
+// import { Markdown } from 'components/Markdown';
+// import { MdeEditor } from 'components/MdeEditor';
+// import {
+//   ProjectDescription,
+//   ProjectHeading,
+//   ProjectInfoContainer,
+//   ReadmeHtmlContainer,
+// } from './layout-components';
 
 import EditorPanels from 'components/EditorPanels';
 import { ChildProps, SXStyles } from 'src/types';
@@ -90,11 +90,11 @@ const compareContracts = (prev: Account[], current: Account[]) => {
   return true;
 };
 
-const MAX_DESCRIPTION_SIZE = Math.pow(1024, 2); // 1mb of storage can be saved into readme field
-const calculateSize = (readme: string) => {
-  const { size } = new Blob([readme]);
-  return size >= MAX_DESCRIPTION_SIZE;
-};
+// const MAX_DESCRIPTION_SIZE = Math.pow(1024, 2); // 1mb of storage can be saved into readme field
+// const calculateSize = (readme: string) => {
+//   const { size } = new Blob([readme]);
+//   return size >= MAX_DESCRIPTION_SIZE;
+// };
 
 const EditorContainer = ({
   isLoading,
@@ -111,9 +111,9 @@ const EditorContainer = ({
 
   const projectAccess = useProject();
 
-  const [descriptionOverflow, setDescriptionOverflow] = useState(
-    calculateSize(project.readme),
-  );
+  // const [descriptionOverflow, setDescriptionOverflow] = useState(
+  //   calculateSize(project.readme),
+  // );
 
   useEffect(() => {
     if (isLoading) {
@@ -141,27 +141,28 @@ const EditorContainer = ({
     }
   }, [project]);
 
-  const setProjectProperties = (
-    title: string,
-    description: string,
-    readme: string,
-  ) => {
-    project.title = title;
-    project.description = description;
-    project.readme = readme;
-    active.onChange(title, description, readme);
-  };
+  // const setProjectProperties = (
+  //   title: string,
+  //   description: string,
+  //   readme: string,
+  // ) => {
+  //   project.title = title;
+  //   project.description = description;
+  //   project.readme = readme;
+  //   active.onChange(title, description, readme);
+  // };
 
-  const isReadmeEditor = active.type === EntityType.Readme;
-  const readmeLabel = `README.md${
-    descriptionOverflow ? " - Content can't be more than 1Mb in size" : ''
-  }`;
+  // const isReadmeEditor = active.type === EntityType.Readme;
+
+  // const readmeLabel = `README.md${
+  //   descriptionOverflow ? " - Content can't be more than 1Mb in size" : ''
+  // }`;
 
   return (
     <Flex sx={styles.editorContainer}>
       <EditorRoot>
-        {/* This is Project Info Block */}
-        <ProjectInfoContainer show={isReadmeEditor}>
+        {/* This is Project Info Block, PRODUCT INFO (ReadMe) REMOVED FOR v2 MVP */}
+        {/* <ProjectInfoContainer show={isReadmeEditor}>
           {project.parentId && !project.persist ? (
             <>
               <ProjectHeading>{title}</ProjectHeading>
@@ -219,8 +220,8 @@ const EditorContainer = ({
               />
             </>
           )}
-        </ProjectInfoContainer>
-        <EditorPanels show={!isReadmeEditor} />
+        </ProjectInfoContainer> */}
+        <EditorPanels show={true} />
       </EditorRoot>
     </Flex>
   );

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -9,7 +9,6 @@ import { createDefaultProject } from './projectDefault';
 import useGetProject from './projectHooks';
 import ProjectMutator, { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 import { storageMap } from 'util/accounts';
-import { getStorageData } from 'util/storage';
 
 export enum EntityType {
   AccountStorage,

--- a/src/providers/Project/projectDefault.ts
+++ b/src/providers/Project/projectDefault.ts
@@ -184,7 +184,6 @@ export function createLocalProject(
   const accountEntities: Account[] = accounts.map((_account, i) => {
     return {
       __typename: 'Account',
-      id: `local-account-${i}`,
       address: `000000000000000${i + 1}`,
       deployedContracts: [],
       state: DEFAULT_ACCOUNT_STATE,

--- a/src/util/accounts.ts
+++ b/src/util/accounts.ts
@@ -1,5 +1,5 @@
 export const storageMap: { [account: string]: number } = {
-  none: 0,
+  none: -1,
   '0x01': 0,
   '0x02': 1,
   '0x03': 2,


### PR DESCRIPTION
Closes: #472 

## Description

- refactored account storage view from separate view to editor view
- removed project info/readme code temporarily
- added editor header feature
- added copy button for code

new header
![image](https://user-images.githubusercontent.com/23225108/204731928-a6c0d66f-73a8-400e-bba9-6588af13b796.png)

account storage view
![image](https://user-images.githubusercontent.com/23225108/204731976-e25e0e34-8de3-43e2-a186-8394085cf5b5.png)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

