### PR TITLE
fix issue where last file was getting deleted

### DIFF
--- a/src/components/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/CadenceEditor/ControlPanel/components.tsx
@@ -11,7 +11,9 @@ export const MotionBox = (props: any) => {
       className="drag-box"
       drag={true}
       dragConstraints={dragConstraints}
-      dragElastic={1}
+      dragElastic={0}
+      whileDrag={{ scale: '1.1', opacity: '0.5' }}
+      dragMomentum={false}
     >
       {children}
     </motion.div>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -34,10 +34,11 @@ const styles: SXStyles = {
     position: 'absolute',
     zIndex: '100', // todo: create zIndex constant in theme object
     margin: '0',
-    right: '5px',
-    bottom: '12px',
+    right: '0',
+    bottom: '22px',
     background: theme.colors.white,
     padding: '8px 4px',
+    whiteSpace: 'nowrap',
   },
   ctaButton: {
     alignSelf: 'baseline',

--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -84,6 +84,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
         } else {
           setShowDeleteError(true);
         }
+        break;
       case 'Script':
         if (project.scriptTemplates.length > 1) {
           await deleteScriptTemplate(templateId);
@@ -92,6 +93,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
         } else {
           setShowDeleteError(true);
         }
+        break;
       default:
         if (project.contractTemplates.length > 1) {
           await deleteContractTemplate(templateId);

--- a/src/components/InformationalPopup.tsx
+++ b/src/components/InformationalPopup.tsx
@@ -16,7 +16,7 @@ const InformationalPopup = ({
 }: InformationalPopupType) => {
   const buttons: ActionsType[] = [
     {
-      name: 'Confirm',
+      name: 'Ok',
       variant: 'primary',
       action: onClose,
       args: [false],


### PR DESCRIPTION
Closes: #474 
Closes: #468
Closes: #475

## Description


![2022-12-05 11 10 46](https://user-images.githubusercontent.com/3970376/205699453-90b6b10b-7aee-437d-9a6e-4d2f07846953.gif)



Fixed: 
1. User was prompt to inform them they can not delete last file, last file was deleted anyway
2. removed momentum of signer modal
3. fixed context menu squashing causing text to wrap

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

