### PR TITLE
disable save button if user has 10 projects saved

### DIFF
--- a/src/components/NewProjectButton.tsx
+++ b/src/components/NewProjectButton.tsx
@@ -5,7 +5,7 @@ import Button, { ButtonProps } from './Button';
 import PlusIcon from './Icons/PlusIcon';
 import Tooltip from './Tooltip';
 
-const MAX_PROJECTS = 10;
+export const MAX_PROJECTS = 10;
 
 type NewProjectButtonProps = {
   label?: string;

--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -26,29 +26,24 @@ export const SaveButton = () => {
   const { projects } = useProjects();
   const hasReachedProjectsLimit = projects.length >= MAX_PROJECTS;
 
-  let showText = Boolean(project?.updatedAt);
+  const isSaved = Boolean(project?.updatedAt);
 
   const saveClicked = () => {
     Mixpanel.track('Save project clicked', { projectId });
     saveProject();
   };
 
-  const timeAgo = showText
+  const timeAgo = isSaved
     ? formatDistance(new Date(project.updatedAt), new Date(), {
         addSuffix: false,
       })
     : null;
 
-  let buttonLabel = timeAgo ? `Saved ${timeAgo}` : `Save`;
-
-  if (!projectId && hasReachedProjectsLimit) {
-    buttonLabel =  "Max projects reached"
-    showText = true;
-  }
+  const buttonLabel = timeAgo ? `Saved ${timeAgo}` : `Save`;
 
   return (
     <Container sx={styles.container}>
-      {showText ? (
+      {isSaved ? (
         <Text>{buttonLabel}</Text>
       ) : (
         <Button
@@ -56,7 +51,7 @@ export const SaveButton = () => {
           variant="alternate"
           size="sm"
           inline={true}
-          disabled={showText || isSaving }
+          disabled={isSaved || isSaving || hasReachedProjectsLimit }
         >
           {buttonLabel}
         </Button>

--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -26,24 +26,29 @@ export const SaveButton = () => {
   const { projects } = useProjects();
   const hasReachedProjectsLimit = projects.length >= MAX_PROJECTS;
 
-  const isSaved = Boolean(project?.updatedAt);
+  let showText = Boolean(project?.updatedAt);
 
   const saveClicked = () => {
     Mixpanel.track('Save project clicked', { projectId });
     saveProject();
   };
 
-  const timeAgo = isSaved
+  const timeAgo = showText
     ? formatDistance(new Date(project.updatedAt), new Date(), {
         addSuffix: false,
       })
     : null;
 
-  const buttonLabel = timeAgo ? `Saved ${timeAgo}` : `Save`;
+  let buttonLabel = timeAgo ? `Saved ${timeAgo}` : `Save`;
+
+  if (!projectId && hasReachedProjectsLimit) {
+    buttonLabel =  "Max projects reached"
+    showText = true;
+  }
 
   return (
     <Container sx={styles.container}>
-      {isSaved ? (
+      {showText ? (
         <Text>{buttonLabel}</Text>
       ) : (
         <Button
@@ -51,7 +56,7 @@ export const SaveButton = () => {
           variant="alternate"
           size="sm"
           inline={true}
-          disabled={isSaved || isSaving || hasReachedProjectsLimit }
+          disabled={showText || isSaving }
         >
           {buttonLabel}
         </Button>

--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -6,6 +6,8 @@ import { Container, Text } from 'theme-ui';
 import { useProject } from 'providers/Project/projectHooks';
 import { LOCAL_PROJECT_ID } from 'util/url';
 import { formatDistance } from 'date-fns';
+import useProjects from '../../hooks/useProjects';
+import { MAX_PROJECTS } from 'components/NewProjectButton';
 
 const styles: SXStyles = {
   container: {
@@ -21,6 +23,9 @@ export const SaveButton = () => {
       : window.location.pathname.slice(1);
 
   const { project, isSaving, saveProject } = useProject();
+  const { projects } = useProjects();
+  const hasReachedProjectsLimit = projects.length >= MAX_PROJECTS;
+
   const isSaved = Boolean(project?.updatedAt);
 
   const saveClicked = () => {
@@ -46,7 +51,7 @@ export const SaveButton = () => {
           variant="alternate"
           size="sm"
           inline={true}
-          disabled={isSaved || isSaving}
+          disabled={isSaved || isSaving || hasReachedProjectsLimit }
         >
           {buttonLabel}
         </Button>

--- a/src/components/TopNav/SaveButton.tsx
+++ b/src/components/TopNav/SaveButton.tsx
@@ -51,7 +51,7 @@ export const SaveButton = () => {
           variant="alternate"
           size="sm"
           inline={true}
-          disabled={isSaved || isSaving || hasReachedProjectsLimit }
+          disabled={isSaved || isSaving || hasReachedProjectsLimit}
         >
           {buttonLabel}
         </Button>


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/513


## Description

If user already has 10 projects save disable save button


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

