### PR TITLE
fix account selection when deploying contract

### DIFF
--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -294,8 +294,9 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             setShowPrompt(true);
             return;
           }
+          const selectedAccountId = selected[0]
           resultType = ResultType.Contract;
-          rawResult = await contractDeployment();
+          rawResult = await contractDeployment(active.index, selectedAccountId);
           break;
         }
         default:

--- a/src/components/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/CadenceEditor/ControlPanel/index.tsx
@@ -294,7 +294,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             setShowPrompt(true);
             return;
           }
-          const selectedAccountId = selected[0]
+          const selectedAccountId = selected[0] || 0;
           resultType = ResultType.Contract;
           rawResult = await contractDeployment(active.index, selectedAccountId);
           break;

--- a/src/components/CadenceEditor/ControlPanel/types.tsx
+++ b/src/components/CadenceEditor/ControlPanel/types.tsx
@@ -16,7 +16,7 @@ export type TransactionExecution = (
   signingAccounts: Account[],
   args?: string[],
 ) => Promise<any>;
-export type DeployExecution = () => Promise<any>;
+export type DeployExecution = (fileIndex: number, accountId: number) => Promise<any>;
 
 export type ProcessingArgs = {
   disabled: boolean;

--- a/src/components/CadenceEditor/ControlPanel/types.tsx
+++ b/src/components/CadenceEditor/ControlPanel/types.tsx
@@ -16,7 +16,10 @@ export type TransactionExecution = (
   signingAccounts: Account[],
   args?: string[],
 ) => Promise<any>;
-export type DeployExecution = (fileIndex: number, accountId: number) => Promise<any>;
+export type DeployExecution = (
+  fileIndex: number,
+  accountId: number,
+) => Promise<any>;
 
 export type ProcessingArgs = {
   disabled: boolean;

--- a/src/components/CadenceEditor/ControlPanel/utils.tsx
+++ b/src/components/CadenceEditor/ControlPanel/utils.tsx
@@ -98,8 +98,8 @@ export const getLabel = (
 };
 
 export const useTemplateType = (): ProcessingArgs => {
-  const { isSaving } = useProject();
   const {
+    isSaving,
     createScriptExecution,
     createTransactionExecution,
     createContractDeployment,

--- a/src/components/SignersPanel/index.tsx
+++ b/src/components/SignersPanel/index.tsx
@@ -110,7 +110,7 @@ export const SignersPanel: React.FC<SignersProps> = ({
         onClick={() => setIsAvatarOpen(!isAvatarOpen)}
       >
         {HeaderText}
-        <Button sx={isAvatarOpen ? styles.carrotDown : styles.root} size="sm">
+        <Button variant="explorer" sx={isAvatarOpen ? styles.carrotDown : styles.root} size="sm">
           {CollapseOpenIcon()}
         </Button>
       </Flex>

--- a/src/components/SignersPanel/index.tsx
+++ b/src/components/SignersPanel/index.tsx
@@ -110,7 +110,11 @@ export const SignersPanel: React.FC<SignersProps> = ({
         onClick={() => setIsAvatarOpen(!isAvatarOpen)}
       >
         {HeaderText}
-        <Button variant="explorer" sx={isAvatarOpen ? styles.carrotDown : styles.root} size="sm">
+        <Button
+          variant="explorer"
+          sx={isAvatarOpen ? styles.carrotDown : styles.root}
+          size="sm"
+        >
           {CollapseOpenIcon()}
         </Button>
       </Flex>

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -36,7 +36,7 @@ export interface ProjectContextValue {
   ) => Promise<any>;
   saveProject: () => Promise<any>;
   deleteProject: (projectId: string) => Promise<any>;
-  createContractDeployment: () => Promise<any>;
+  createContractDeployment: (fileIndex: number, accountId: number) => Promise<any>;
   updateSelectedContractAccount: (accountIndex: number) => void;
   updateSelectedTransactionAccounts: (accountIndexes: number[]) => void;
   updateActiveContractTemplate: (script: string) => Promise<any>;
@@ -253,14 +253,17 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     return res;
   };
 
-  const createContractDeployment: any = async () => {
+  const createContractDeployment: any = async (fileIndex: number, accountId: number) => {
     setIsSaving(true);
     setIsExecutingAction(true);
     let res;
     try {
+      const deployAccount = project.accounts[accountId];
+      const template = project.contractTemplates[fileIndex];
+      console.log(accountId, 'deploy to account', deployAccount)
       res = await mutator.createContractDeployment(
-        project.contractTemplates[active.index],
-        project.accounts[active.index],
+        template,
+        deployAccount,
         active.index,
       );
 

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -266,7 +266,6 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     try {
       const deployAccount = project.accounts[accountId];
       const template = project.contractTemplates[fileIndex];
-      console.log(accountId, 'deploy to account', deployAccount);
       res = await mutator.createContractDeployment(
         template,
         deployAccount,

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -36,7 +36,10 @@ export interface ProjectContextValue {
   ) => Promise<any>;
   saveProject: () => Promise<any>;
   deleteProject: (projectId: string) => Promise<any>;
-  createContractDeployment: (fileIndex: number, accountId: number) => Promise<any>;
+  createContractDeployment: (
+    fileIndex: number,
+    accountId: number,
+  ) => Promise<any>;
   updateSelectedContractAccount: (accountIndex: number) => void;
   updateSelectedTransactionAccounts: (accountIndexes: number[]) => void;
   updateActiveContractTemplate: (script: string) => Promise<any>;
@@ -253,14 +256,17 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     return res;
   };
 
-  const createContractDeployment: any = async (fileIndex: number, accountId: number) => {
+  const createContractDeployment: any = async (
+    fileIndex: number,
+    accountId: number,
+  ) => {
     setIsSaving(true);
     setIsExecutingAction(true);
     let res;
     try {
       const deployAccount = project.accounts[accountId];
       const template = project.contractTemplates[fileIndex];
-      console.log(accountId, 'deploy to account', deployAccount)
+      console.log(accountId, 'deploy to account', deployAccount);
       res = await mutator.createContractDeployment(
         template,
         deployAccount,


### PR DESCRIPTION
Closes: #508

## Description

weird "active" property was used for both contract template selected and account. Changed to pass in the signer for the deployed contract. 
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

