### PR TITLE
tell user to clear application data if they get authorization error

### DIFF
--- a/src/api/apollo/client.ts
+++ b/src/api/apollo/client.ts
@@ -50,7 +50,7 @@ const client = new ApolloClient({
           break;
         case 'AUTHORIZATION_ERROR':
           console.log('Encountered Authorization Error', gqlError);
-          errorMessage = 'User Not Authorized. Please check your cookies.';
+          errorMessage = 'User Not Authorized. Please clear application data and/or make sure cookies are enabled.';
           break;
         default:
           errorMessage = '';

--- a/src/api/apollo/client.ts
+++ b/src/api/apollo/client.ts
@@ -50,7 +50,8 @@ const client = new ApolloClient({
           break;
         case 'AUTHORIZATION_ERROR':
           console.log('Encountered Authorization Error', gqlError);
-          errorMessage = 'User Not Authorized. Please clear application data and/or make sure cookies are enabled.';
+          errorMessage =
+            'User Not Authorized. Please clear application data and/or make sure cookies are enabled.';
           break;
         default:
           errorMessage = '';


### PR DESCRIPTION
References: #490 

## Description

Appears that the api doesn't like the user's cookie. The session cookie exists but there is no user data in the db. In this instance the user will have to create a new session by clearing their browsers application data. This is an annoying work around for now. 

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

