### PR TITLE
Add functionality to Error pane

### DIFF
--- a/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
+++ b/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
@@ -65,7 +65,7 @@ const TabIndicator = ({ selected }: { selected: boolean }) => {
 };
 
 const BottomEditorPanelHeader = ({
-  problems,
+  problems, 
   selectedBottomTab,
   setSelectedBottomTab,
 }: BottomEditorPanelHeaderProps) => {

--- a/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
+++ b/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
@@ -65,7 +65,7 @@ const TabIndicator = ({ selected }: { selected: boolean }) => {
 };
 
 const BottomEditorPanelHeader = ({
-  problems, 
+  problems,
   selectedBottomTab,
   setSelectedBottomTab,
 }: BottomEditorPanelHeaderProps) => {

--- a/src/components/Editor/BottomEditorPanel/RenderError.tsx
+++ b/src/components/Editor/BottomEditorPanel/RenderError.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { CadenceProblem } from 'util/language-syntax-errors';
+import {
+  CadenceProblem,
+  goTo,
+  hideDecorations,
+  Highlight,
+  hover,
+} from 'util/language-syntax-errors';
 import { ErrorMessage } from '../CadenceEditor/ControlPanel/Arguments/styles';
 import { renderMessage } from '../CadenceEditor/ControlPanel/Arguments/components';
 import { Flex } from 'theme-ui';
 import { SXStyles } from 'src/types';
+import { useProject } from 'providers/Project/projectHooks';
+import { IPosition } from 'monaco-editor';
 
 const styles: SXStyles = {
   root: {
@@ -44,7 +52,14 @@ const styles: SXStyles = {
 };
 
 const RenderError = (props: any) => {
+  const { currentEditor } = useProject();
   const list = props.list.error ?? [];
+
+  const actions = {
+    goTo: (position: IPosition) => goTo(currentEditor, position),
+    hideDecorations: () => hideDecorations(currentEditor),
+    hover: (highlight: Highlight) => hover(currentEditor, highlight),
+  };
 
   return (
     <Flex sx={styles.root}>
@@ -53,9 +68,15 @@ const RenderError = (props: any) => {
           ? [...list].reverse().map((item: CadenceProblem, i: number) => {
               const message = renderMessage(item.message);
               return (
-                <Flex sx={styles.errorLine} key={i}>
+                <Flex
+                  onClick={() => actions.goTo(item.position)}
+                  onMouseOver={() => actions.hover(item.highlight)}
+                  onMouseOut={() => actions. hideDecorations()}
+                  sx={styles.errorLine}
+                  key={i}
+                >
                   <Flex sx={styles.index}>
-                    <span>{i + 1}</span>
+                    <span>Line: {item.position.lineNumber}</span>
                   </Flex>
                   <ErrorMessage>{message}</ErrorMessage>
                 </Flex>

--- a/src/components/Editor/BottomEditorPanel/RenderError.tsx
+++ b/src/components/Editor/BottomEditorPanel/RenderError.tsx
@@ -71,7 +71,7 @@ const RenderError = (props: any) => {
                 <Flex
                   onClick={() => actions.goTo(item.position)}
                   onMouseOver={() => actions.hover(item.highlight)}
-                  onMouseOut={() => actions. hideDecorations()}
+                  onMouseOut={() => actions.hideDecorations()}
                   sx={styles.errorLine}
                   key={i}
                 >

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
@@ -157,6 +157,7 @@ export const StatusMessage = styled.div<MessageProps>`
   padding: ${({ isOk }) => (isOk ? '1rem' : 'unset')};
   justify-content: flex-start;
   font-size: 16px;
+  cursor: pointer;
   svg {
     margin-right: 5px;
   }

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -354,6 +354,10 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     hover: (highlight: Highlight) => hover(editor, highlight),
   };
 
+  const openErrorPanel = () => {
+    props.setSelectedBottomTab(1);
+    setShowBottomPanel(true);
+  }
   const isOk =
     !haveErrors && validCode !== undefined && !!validCode && !notEnoughSigners;
   let statusIcon;
@@ -442,6 +446,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
               <StatusMessage
                 isOk={isOk}
                 data-test="control-panel-status-message"
+                onClick={openErrorPanel}
               >
                 <StatusIcon isOk={isOk} progress={progress} showPrompt={false}>
                   {statusIcon}

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -358,6 +358,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     props.setSelectedBottomTab(1);
     setShowBottomPanel(true);
   }
+  
   const isOk =
     !haveErrors && validCode !== undefined && !!validCode && !notEnoughSigners;
   let statusIcon;

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -357,8 +357,8 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   const openErrorPanel = () => {
     props.setSelectedBottomTab(1);
     setShowBottomPanel(true);
-  }
-  
+  };
+
   const isOk =
     !haveErrors && validCode !== undefined && !!validCode && !notEnoughSigners;
   let statusIcon;

--- a/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
@@ -9,6 +9,7 @@ export type ControlPanelProps = {
   problemsList: any;
   setProblemsList: any;
   editor: monacoEditor.ICodeEditor;
+  setSelectedBottomTab: (index: number) => void;
 };
 
 export type ScriptExecution = (args?: string[]) => Promise<any>;

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -11,8 +11,14 @@ import { EntityType } from 'providers/Project';
 const MONACO_CONTAINER_ID = 'monaco-container';
 
 type EditorStates = Record<number, EditorState>;
+export type CadenceEditorProps = {
+  problemsList: any[];
+  setProblemsList: Function;
+  show: boolean;
+  setSelectedBottomTab: (index: number) => void;
+}
 
-const CadenceEditor = (props: any) => {
+const CadenceEditor = (props: CadenceEditorProps) => {
   const project = useProject();
   const [editor, setEditor] = useState(null);
   const editorOnChange = useRef(null);
@@ -179,6 +185,7 @@ const CadenceEditor = (props: any) => {
           problemsList={props.problemsList}
           setProblemsList={props.setProblemsList}
           editor={editor}
+          setSelectedBottomTab={props.setSelectedBottomTab}
         />
       )}
     </EditorContainer>

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -107,6 +107,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
         editor.layout();
 
         newState.model.setValue(code);
+        project.setCurrentEditor(editor);
       }
       editorOnChange.current = editor.onDidChangeModelContent(() => {
         if (project.project?.accounts) {

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -16,7 +16,7 @@ export type CadenceEditorProps = {
   setProblemsList: Function;
   show: boolean;
   setSelectedBottomTab: (index: number) => void;
-}
+};
 
 const CadenceEditor = (props: CadenceEditorProps) => {
   const project = useProject();

--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -70,7 +70,7 @@ const styles: SXStyles = {
     color: '#3031D1',
   },
   titleText: {
-    width: '125px',
+    minWidth: '125px',
     paddingLeft: '4px',
   },
   icon: {

--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -130,7 +130,7 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
     <Flex sx={styles.root}>
       <Flex sx={styles.editor}>
         <Allotment vertical={true}>
-          <Allotment.Pane minSize={EDITOR_HEADER_HEIGHT}>
+          <Allotment.Pane maxSize={EDITOR_HEADER_HEIGHT} minSize={EDITOR_HEADER_HEIGHT}>
             <Flex sx={styles.editorHeader}>
               <Flex sx={styles.editorTitle}>
                 <Box sx={styles.icon}>{getIcon()}</Box>
@@ -151,6 +151,7 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
               problemsList={problemsList}
               setProblemsList={setProblemsList}
               show={show}
+              setSelectedBottomTab={setSelectedBottomTab}
             />
           </Allotment.Pane>
           <Allotment.Pane

--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -130,7 +130,10 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
     <Flex sx={styles.root}>
       <Flex sx={styles.editor}>
         <Allotment vertical={true}>
-          <Allotment.Pane maxSize={EDITOR_HEADER_HEIGHT} minSize={EDITOR_HEADER_HEIGHT}>
+          <Allotment.Pane
+            maxSize={EDITOR_HEADER_HEIGHT}
+            minSize={EDITOR_HEADER_HEIGHT}
+          >
             <Flex sx={styles.editorHeader}>
               <Flex sx={styles.editorTitle}>
                 <Box sx={styles.icon}>{getIcon()}</Box>

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -8,9 +8,7 @@ import { getParams, LOCAL_PROJECT_ID } from 'util/url';
 import useGetProject from './projectHooks';
 import ProjectMutator, { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 import { storageMapByAddress } from 'util/accounts';
-import {
-  editor as monacoEditor,
-} from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor as monacoEditor } from 'monaco-editor/esm/vs/editor/editor.api';
 
 export enum EntityType {
   AccountStorage,
@@ -88,7 +86,7 @@ export interface ProjectContextValue {
   applicationErrorMessage: string;
   setApplicationErrorMessage: (message: string) => void;
   clearApplicationErrors: () => void;
-  setCurrentEditor: (editor: monacoEditor.ICodeEditor) => void; 
+  setCurrentEditor: (editor: monacoEditor.ICodeEditor) => void;
   currentEditor: monacoEditor.ICodeEditor | null;
 }
 
@@ -144,7 +142,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [showProjectsSidebar, setShowProjectsSidebar] = useState(false);
   const [showBottomPanel, setShowBottomPanel] = useState(false);
   const [applicationErrorMessage, setApplicationErrorMessage] = useState('');
-  const [currentEditor, setCurrentEditor] = useState<monacoEditor.ICodeEditor | null>(null);
+  const [currentEditor, setCurrentEditor] =
+    useState<monacoEditor.ICodeEditor | null>(null);
 
   useEffect(() => {
     if (showProjectsSidebar) {
@@ -799,7 +798,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         setApplicationErrorMessage,
         clearApplicationErrors,
         setCurrentEditor,
-        currentEditor
+        currentEditor,
       }}
     >
       {children}

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -8,6 +8,9 @@ import { getParams, LOCAL_PROJECT_ID } from 'util/url';
 import useGetProject from './projectHooks';
 import ProjectMutator, { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 import { storageMapByAddress } from 'util/accounts';
+import {
+  editor as monacoEditor,
+} from 'monaco-editor/esm/vs/editor/editor.api';
 
 export enum EntityType {
   AccountStorage,
@@ -85,6 +88,8 @@ export interface ProjectContextValue {
   applicationErrorMessage: string;
   setApplicationErrorMessage: (message: string) => void;
   clearApplicationErrors: () => void;
+  setCurrentEditor: (editor: monacoEditor.ICodeEditor) => void; 
+  currentEditor: monacoEditor.ICodeEditor | null;
 }
 
 export const ProjectContext: React.Context<ProjectContextValue> =
@@ -139,6 +144,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [showProjectsSidebar, setShowProjectsSidebar] = useState(false);
   const [showBottomPanel, setShowBottomPanel] = useState(false);
   const [applicationErrorMessage, setApplicationErrorMessage] = useState('');
+  const [currentEditor, setCurrentEditor] = useState<monacoEditor.ICodeEditor | null>(null);
 
   useEffect(() => {
     if (showProjectsSidebar) {
@@ -792,6 +798,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         applicationErrorMessage,
         setApplicationErrorMessage,
         clearApplicationErrors,
+        setCurrentEditor,
+        currentEditor
       }}
     >
       {children}


### PR DESCRIPTION
closes: https://github.com/onflow/flow-playground/issues/581
references: https://github.com/onflow/flow-playground/issues/579

## Description

Give user ability to find errors in their code. 
Fix editor resizing annoyance

![2023-03-23 11 56 24](https://user-images.githubusercontent.com/3970376/227283449-380e74d2-e400-4cd9-99f2-eafc71f624ce.gif)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

