### PR TITLE
use account and contract index to determine if contract is getting re…

### DIFF
--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
@@ -187,11 +187,17 @@ export const Hints: React.FC<HintsProps> = (props: HintsProps) => {
   );
 };
 
-const getLabel = (type: EntityType, project: Project, active: ActiveEditor) => {
+const getLabel = (
+  type: EntityType,
+  project: Project,
+  active: ActiveEditor,
+  selectedAccounts: number[],
+) => {
   const { accounts } = project;
   switch (true) {
     case type === EntityType.ContractTemplate:
-      return accounts[active.index]?.deployedContracts?.length > 0
+      return active.index in
+        (accounts[selectedAccounts[0] || 0]?.deployedContracts || [])
         ? 'Redeploy'
         : 'Deploy';
     case type === EntityType.TransactionTemplate:
@@ -217,6 +223,7 @@ const getActionButtonTestTag = (type: EntityType) => {
 export const ActionButton: React.FC<InteractionButtonProps> = ({
   type,
   active = true,
+  selectedAccounts = [],
   progress = false,
   onClick,
 }: InteractionButtonProps) => {
@@ -227,7 +234,7 @@ export const ActionButton: React.FC<InteractionButtonProps> = ({
     isSaving,
     isExecutingAction,
   } = useProject();
-  const label = getLabel(type, project, activeEditor);
+  const label = getLabel(type, project, activeEditor, selectedAccounts);
   const code = getActiveCode()[0].trim();
   return (
     <Controls>

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/fa';
 import { CadenceProblem } from 'util/language-syntax-errors';
 import theme from '../../../../../theme';
+import { getSelectedAccount } from '../utils';
 import SingleArgument from './SingleArgument';
 import {
   Badge,
@@ -197,7 +198,8 @@ const getLabel = (
   switch (true) {
     case type === EntityType.ContractTemplate:
       return active.index in
-        (accounts[selectedAccounts[0] || 0]?.deployedContracts || [])
+        (getSelectedAccount(accounts, selectedAccounts)?.deployedContracts ||
+          [])
         ? 'Redeploy'
         : 'Deploy';
     case type === EntityType.TransactionTemplate:

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/types.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/types.tsx
@@ -11,6 +11,7 @@ export type InteractionButtonProps = {
   onClick: () => void;
   active?: boolean;
   progress?: boolean;
+  selectedAccounts: number[];
   type: EntityType;
 };
 

--- a/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
@@ -7,15 +7,15 @@ import { Flex } from 'theme-ui';
 interface AccountPickerProps extends ChildPropsOptional {
   project: Project;
   accounts: Account[];
-  selected: number[];
-  onChange: (selected: number[]) => void;
+  selectedAccounts: number[];
+  onChange: (selectedAccounts: number[]) => void;
   maxSelection?: number;
 }
 
 const AccountPicker = ({
   project,
   accounts,
-  selected,
+  selectedAccounts,
   onChange,
   maxSelection = 4,
 }: AccountPickerProps) => {
@@ -23,19 +23,19 @@ const AccountPicker = ({
     if (max === 1) {
       // behave like radio button
       onChange([i]);
-    } else if (selected.includes(i)) {
-      onChange(selected.filter((j: any) => j !== i));
+    } else if (selectedAccounts.includes(i)) {
+      onChange(selectedAccounts.filter((j: any) => j !== i));
     } else {
-      onChange([...selected, i]);
+      onChange([...selectedAccounts, i]);
     }
   };
 
   useEffect(() => {
-    if (!selected.length) {
+    if (!selectedAccounts.length) {
       onChange([0]);
     }
-    if (selected.length > maxSelection) {
-      onChange(selected.slice(0, maxSelection));
+    if (selectedAccounts.length > maxSelection) {
+      onChange(selectedAccounts.slice(0, maxSelection));
     }
   }, [maxSelection]);
 
@@ -51,7 +51,7 @@ const AccountPicker = ({
         multi={true}
         project={project}
         accounts={accounts}
-        selectedAccounts={selected}
+        selectedAccounts={selectedAccounts}
         onChange={(index: number) => handleOnChange(index, maxSelection)}
         maxSelection={maxSelection}
       />

--- a/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/index.tsx
@@ -11,7 +11,7 @@ import Button from 'components/Button';
 
 type SignersProps = {
   maxSelection?: number;
-  selected: number[];
+  selectedAccounts: number[];
   updateSelectedAccounts: (selection: number[]) => void;
 };
 
@@ -43,22 +43,22 @@ const AvatarIconList = (seed: number, indexes: number[]) => {
 const PanelHeader = (
   maxSelection: number,
   seed: number,
-  selected: number[] = [],
+  selectedAccounts: number[] = [],
 ) => {
   let message = '';
-  const correctNumSigners = selected.length === maxSelection;
+  const correctNumSigners = selectedAccounts.length === maxSelection;
   const SIGNERSSELECTED = 'Signers Selected';
-  if (correctNumSigners && selected.length === 1) {
-    message = `${selected.length} ${SIGNERSSELECTED}`;
+  if (correctNumSigners && selectedAccounts.length === 1) {
+    message = `${selectedAccounts.length} ${SIGNERSSELECTED}`;
   } else if (correctNumSigners) {
-    message = `${selected.length} of ${maxSelection} Signers`;
+    message = `${selectedAccounts.length} of ${maxSelection} Signers`;
   } else {
-    message = `${selected.length} of ${maxSelection} ${SIGNERSSELECTED}`;
+    message = `${selectedAccounts.length} of ${maxSelection} ${SIGNERSSELECTED}`;
   }
 
   return (
     <Flex sx={{ justifyContent: 'flex-start', padding: ' 0.875rem' }}>
-      {AvatarIconList(seed, selected)}
+      {AvatarIconList(seed, selectedAccounts)}
       <Text sx={{ marginLeft: '0.25rem', fontSize: '14px' }}>{message}</Text>
     </Flex>
   );
@@ -78,7 +78,7 @@ const styles: SXStyles = {
 
 export const SignersPanel: React.FC<SignersProps> = ({
   maxSelection,
-  selected,
+  selectedAccounts,
   updateSelectedAccounts,
 }) => {
   const { project } = useProject();
@@ -86,15 +86,15 @@ export const SignersPanel: React.FC<SignersProps> = ({
   const { accounts } = project;
 
   const HeaderText = useMemo(
-    () => PanelHeader(maxSelection, project.seed, selected),
-    [maxSelection, selected, project.seed],
+    () => PanelHeader(maxSelection, project.seed, selectedAccounts),
+    [maxSelection, selectedAccounts, project.seed],
   );
 
   useEffect(() => {
-    if (selected.length === 0 && maxSelection > 0) {
+    if (selectedAccounts.length === 0 && maxSelection > 0) {
       updateSelectedAccounts([0]); // select first signer as default
     }
-  }, [maxSelection, selected, updateSelectedAccounts]);
+  }, [maxSelection, selectedAccounts, updateSelectedAccounts]);
 
   return (
     <SignersContainer>
@@ -109,11 +109,11 @@ export const SignersPanel: React.FC<SignersProps> = ({
           {CollapseOpenIcon()}
         </Button>
       </Flex>
-      {(isAvatarOpen || selected.length === 0) && (
+      {(isAvatarOpen || selectedAccounts.length === 0) && (
         <AccountPicker
           project={project}
           accounts={accounts}
-          selected={selected}
+          selectedAccounts={selectedAccounts}
           onChange={updateSelectedAccounts}
           maxSelection={maxSelection}
         />

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -406,13 +406,6 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     active.index in
       (accounts[selectedAccounts[0] || 0]?.deployedContracts || []);
 
-  console.log(
-    'activateConfirmation',
-    activateConfirmation,
-    accounts,
-    selectedAccounts,
-  );
-
   return (
     <>
       <div ref={constraintsRef} className="constraints" />

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -32,7 +32,12 @@ import {
 // Component Scoped Files
 import { MotionBox, StatusIcon } from './components';
 import { ControlPanelProps, IValue } from './types';
-import { getLabel, useTemplateType, validateByType } from './utils';
+import {
+  getSelectedAccount,
+  getLabel,
+  useTemplateType,
+  validateByType,
+} from './utils';
 
 // Other
 import {
@@ -222,7 +227,6 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
    * Processes arguments and send scripts and transaction for execution or contracts for deployment
    */
   const send = async (isConfirmed: boolean) => {
-    console.log('send', isConfirmed);
     if (!isConfirmed) {
       setShowPrompt(false);
       return;
@@ -288,7 +292,8 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
           if (
             accounts[active.index] &&
             active.index in
-              (accounts[selectedAccounts[0] || 0]?.deployedContracts || []) &&
+              (getSelectedAccount(accounts, selectedAccounts)
+                ?.deployedContracts || []) &&
             !showPrompt
           ) {
             setProcessingStatus(false);
@@ -404,7 +409,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   const activateConfirmation =
     type === EntityType.ContractTemplate &&
     active.index in
-      (accounts[selectedAccounts[0] || 0]?.deployedContracts || []);
+      (getSelectedAccount(accounts, selectedAccounts)?.deployedContracts || []);
 
   return (
     <>

--- a/src/components/Editor/CadenceEditor/ControlPanel/utils.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/utils.tsx
@@ -1,4 +1,4 @@
-import { ResultType } from 'api/apollo/generated/graphql';
+import { Account, ResultType } from 'api/apollo/generated/graphql';
 import { useProject } from 'providers/Project/projectHooks';
 import { ProcessingArgs } from './types';
 
@@ -111,4 +111,11 @@ export const useTemplateType = (): ProcessingArgs => {
     transactionFactory: createTransactionExecution,
     contractDeployment: createContractDeployment,
   };
+};
+
+export const getSelectedAccount = (
+  accounts: Account[],
+  selectedAccounts: number[],
+): Account => {
+  return accounts[selectedAccounts[0] || 0];
 };


### PR DESCRIPTION
Closes: #507 

## Description

 - Small refactor changed `selected` to `selectedAccounts` to be more readable.
 - Use selected account and the contract file index to determine if the contract file is getting redeployed.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

