### PR TITLE
sort contracts to see if this works on staging

### DIFF
--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -135,7 +135,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
         <MenuList
           title="Contracts"
           itemType={EntityType.ContractTemplate}
-          items={project.contractTemplates.sort(c => c.index)}
+          items={project.contractTemplates.sort((c) => c.index)}
           itemTitles={project.contractTemplates?.map((template) => {
             return template.title;
           })}

--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -135,7 +135,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
         <MenuList
           title="Contracts"
           itemType={EntityType.ContractTemplate}
-          items={project.contractTemplates}
+          items={project.contractTemplates.sort(c => c.index)}
           itemTitles={project.contractTemplates?.map((template) => {
             return template.title;
           })}


### PR DESCRIPTION
References: https://github.com/onflow/flow-playground/issues/529

## Description

Test to see if contract templates stay sorted, only seeing this issue on staging.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

