### PR TITLE
set local variable filename after change before sending to backend

### DIFF
--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -129,10 +129,6 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
       );
     }
 
-    console.log(
-      'project.contractTemplates',
-      project.contractTemplates.map((c) => c.title),
-    );
     return (
       <>
         <Flex sx={styles.header}>FILES</Flex>

--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -129,6 +129,10 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
       );
     }
 
+    console.log(
+      'project.contractTemplates',
+      project.contractTemplates.map((c) => c.title),
+    );
     return (
       <>
         <Flex sx={styles.header}>FILES</Flex>

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -116,7 +116,7 @@ const styles: SXStyles = {
   },
 };
 
-export interface TitledScript {
+interface TitledScript {
   script: string;
   title: string;
   id: string;

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -116,10 +116,16 @@ const styles: SXStyles = {
   },
 };
 
+export interface TitledScript {
+  script: string;
+  title: string;
+  id: string;
+}
+
 type MenuListProps = {
   itemType: EntityType;
   title?: string;
-  items: any[];
+  items: TitledScript[];
   itemTitles: any[];
   onSelect: (e: SyntheticEvent, id: string) => void;
   onUpdate: any;
@@ -153,6 +159,7 @@ const MenuList: React.FC<MenuListProps> = ({
       let _editing = [...editing];
       _editing.splice(_editing.indexOf(i), 1);
       setEditing(_editing);
+      items[i].title = newTitle;
       onUpdate(items[i].id, items[i].script, newTitle);
       return;
     }

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -291,6 +291,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     try {
+      project.contractTemplates[active.index].script = script;
+      project.contractTemplates[active.index].title = title;
       res = await mutator.updateContractTemplate(
         project.contractTemplates[active.index],
         script,
@@ -312,6 +314,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     const contractTemplate = project.contractTemplates[active.index];
+    contractTemplate.script = script;
     try {
       res = await mutator.updateContractTemplate(
         project.contractTemplates[active.index],


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/598

## Description

Since removing forced refresh, need to set local filename variable then update backend.
Set title in Ui component so the filename doesn't revert for a second then update. 

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

