### PR TITLE
Sort template collections

### DIFF
--- a/src/api/apollo/queries.ts
+++ b/src/api/apollo/queries.ts
@@ -75,6 +75,15 @@ export const GET_PROJECT = gql`
   }
 `;
 
+export const GET_PROJECT_UPDATE_AT = gql`
+  query GetProject($projectId: UUID!) {
+    project(id: $projectId) {
+      id
+      updatedAt
+    }
+  }
+`;
+
 export const GET_LOCAL_PROJECT = gql`
   query GetLocalProject {
     project: localProject @client {

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -10,7 +10,7 @@ import Input from './ExplorerInput';
 import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { SyntheticEvent, useEffect, useState } from 'react';
-import { SXStyles } from 'src/types';
+import { SXStyles, Template } from 'src/types';
 import { Box, Flex } from 'theme-ui';
 import { getParams } from 'util/url';
 import { ContextMenu } from '../../ContextMenu';
@@ -116,16 +116,10 @@ const styles: SXStyles = {
   },
 };
 
-interface TitledScript {
-  script: string;
-  title: string;
-  id: string;
-}
-
 type MenuListProps = {
   itemType: EntityType;
   title?: string;
-  items: TitledScript[];
+  items: Template[];
   itemTitles: any[];
   onSelect: (e: SyntheticEvent, id: string) => void;
   onUpdate: any;

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -291,14 +291,15 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     try {
-      project.contractTemplates[active.index].script = script;
-      project.contractTemplates[active.index].title = title;
+      const template = project.contractTemplates[active.index];
       res = await mutator.updateContractTemplate(
-        project.contractTemplates[active.index],
+        template,
         script,
         title,
         active.index,
       );
+      template.script = script;
+      template.title = title;
     } catch (e) {
       console.error(e);
       setIsSaving(false);
@@ -314,7 +315,6 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     const contractTemplate = project.contractTemplates[active.index];
-    contractTemplate.script = script;
     try {
       res = await mutator.updateContractTemplate(
         project.contractTemplates[active.index],
@@ -322,6 +322,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         contractTemplate.title,
         active.index,
       );
+      contractTemplate.script = script;
     } catch (e) {
       console.error(e);
       setIsSaving(false);
@@ -342,6 +343,9 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     let res;
     try {
       res = await mutator.updateScriptTemplate(templateId, script, title);
+      const template = project.scriptTemplates.find((t) => t.id === templateId);
+      template.script = script;
+      template.title = title;
     } catch (e) {
       console.error(e);
       setIsSaving(false);
@@ -362,6 +366,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     let res;
     try {
       res = await mutator.updateTransactionTemplate(templateId, script, title);
+      const template = project.transactionTemplates.find(
+        (t) => t.id === templateId,
+      );
+      template.script = script;
+      template.title = title;
     } catch (e) {
       console.error(e);
       setIsSaving(false);
@@ -376,6 +385,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const updateActiveScriptTemplate = async (script: string) => {
     setIsSaving(true);
     let res;
+    const template = project.scriptTemplates[active.index];
+    template.script = script;
     try {
       res = await mutator.updateScriptTemplate(
         project.scriptTemplates[active.index].id,
@@ -396,6 +407,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const updateActiveTransactionTemplate = async (script: string) => {
     setIsSaving(true);
     let res;
+    const template = project.transactionTemplates[active.index];
+    template.script = script;
     try {
       res = await mutator.updateTransactionTemplate(
         project.transactionTemplates[active.index].id,

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -8,6 +8,14 @@ import { ProjectContext, ProjectContextValue } from './index';
 import { createDefaultProject, createLocalProject } from './projectDefault';
 import { PROJECT_SERIALIZATION_KEY } from './projectMutator';
 
+function formatProject(project: Project) {
+  // sort based on index, issue getting this to work in the backend
+  project.contractTemplates.sort((a, b) => a.index - b.index);
+  project.scriptTemplates.sort((a, b) => a.index - b.index);
+  project.transactionTemplates.sort((a, b) => a.index - b.index);
+  return project;
+}
+
 function writeDefaultProject(client: any) {
   const defaultProject = createDefaultProject();
 
@@ -98,7 +106,7 @@ export default function useGetProject(
     return { project: null, isLocal: false, isClone: false, isLoading: true };
   }
 
-  const remoteProject = remoteData.project;
+  const remoteProject = formatProject(remoteData.project);
   const isMutable = remoteProject.mutable;
 
   if (!isMutable) {
@@ -115,7 +123,7 @@ export default function useGetProject(
   }
 
   return {
-    project: remoteData.project,
+    project: remoteProject,
     isLocal: false,
     isClone: false,
     isLoading: false,

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -29,6 +29,7 @@ import {
   GET_APPLICATION_ERRORS,
   GET_LOCAL_PROJECT,
   GET_PROJECT,
+  GET_PROJECT_UPDATE_AT,
 } from 'api/apollo/queries';
 
 import Mixpanel from 'util/mixpanel';
@@ -38,6 +39,7 @@ import {
 } from 'util/onclose';
 import { createDefaultProject, DEFAULT_ACCOUNT_STATE } from './projectDefault';
 import { UrlRewritter, FILE_TYPE_NAME } from 'util/urlRewritter';
+import { Template } from 'src/types';
 
 // TODO: Switch to directives for serialization keys after upgrading to the newest Apollo/apollo-link-serialize
 export const PROJECT_SERIALIZATION_KEY = 'PROJECT_SERIALIZATION_KEY';
@@ -98,16 +100,18 @@ export default class ProjectMutator {
     const description = newProject.description;
     const readme = newProject.readme;
     const transactionTemplates = newProject.transactionTemplates.map(
-      (tpl: any) => ({ script: tpl.script, title: tpl.title }),
+      (tpl: Template) => ({ script: tpl.script, title: tpl.title }),
     );
-    const scriptTemplates = newProject.scriptTemplates.map((tpl: any) => ({
+    const scriptTemplates = newProject.scriptTemplates.map((tpl: Template) => ({
       script: tpl.script,
       title: tpl.title,
     }));
-    const contractTemplates = newProject.contractTemplates.map((tpl: any) => ({
-      script: tpl.script,
-      title: tpl.title,
-    }));
+    const contractTemplates = newProject.contractTemplates.map(
+      (tpl: Template) => ({
+        script: tpl.script,
+        title: tpl.title,
+      }),
+    );
 
     const { data } = await this.client.mutate({
       mutation: CREATE_PROJECT,
@@ -290,7 +294,10 @@ export default class ProjectMutator {
         title,
       },
       refetchQueries: [
-        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+        {
+          query: GET_PROJECT_UPDATE_AT,
+          variables: { projectId: this.projectId },
+        },
       ],
       context: {
         debounceKey: key,
@@ -415,7 +422,10 @@ export default class ProjectMutator {
         title: title,
       },
       refetchQueries: [
-        { query: GET_PROJECT, variables: { projectId: this.projectId } },
+        {
+          query: GET_PROJECT_UPDATE_AT,
+          variables: { projectId: this.projectId },
+        },
       ],
       context: {
         debounceKey: key,
@@ -663,6 +673,12 @@ export default class ProjectMutator {
         index,
         projectId: this.projectId,
       },
+      refetchQueries: [
+        {
+          query: GET_PROJECT_UPDATE_AT,
+          variables: { projectId: this.projectId },
+        },
+      ],
       context: {
         debounceKey: key,
         serializationKey: PROJECT_SERIALIZATION_KEY,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export type ProjectType = {
 };
 
 export type Template = {
-  id: number;
+  id: string;
   script: string;
   title: string;
 };


### PR DESCRIPTION
Closes: #529 

## Description

sort template collections after fetching. there seems to be an issue on the backend sorting based on template index. Also refetch only `updatedAt` property after updating template.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

