### PR TITLE
fix toggle project left panel and use project list cache

### DIFF
--- a/src/components/LeftSidebar/index.tsx
+++ b/src/components/LeftSidebar/index.tsx
@@ -21,6 +21,7 @@ const LeftSidebar = () => {
     const handleClickOutside = (event: Event) => {
       if (ref.current && !ref.current.contains(event.target)) {
         toggleProjectsSidebar();
+        event.stopPropagation();
       }
     };
     document.addEventListener('click', handleClickOutside, true);

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -6,7 +6,7 @@ export default function useProjects() {
   // TODO: figure out how to update project list in cache when project is added, deleted or name changed
   const { loading, error, data, refetch } = useQuery<{
     projectList: ProjectListType;
-  }>(GET_PROJECTS, { fetchPolicy: 'no-cache' });
+  }>(GET_PROJECTS, { fetchPolicy: 'cache-and-network' });
 
   const projects = data?.projectList?.projects || [];
 


### PR DESCRIPTION


Closes: https://github.com/onflow/flow-playground/issues/603
References: #595 

## Description

use cache when user opens project pane.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

