### PR TITLE
better formatting of project loading error indicator

### DIFF
--- a/src/components/LeftSidebar/ProjectsList.tsx
+++ b/src/components/LeftSidebar/ProjectsList.tsx
@@ -16,7 +16,7 @@ const styles: SXStyles = {
     alignSelf: 'center',
     padding: '1rem 0',
     color: 'red',
-  }
+  },
 };
 
 const ProjectsList = () => {

--- a/src/components/LeftSidebar/ProjectsList.tsx
+++ b/src/components/LeftSidebar/ProjectsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProjectType, SXStyles } from 'src/types';
-import { Flex } from 'theme-ui';
+import { Box, Flex } from 'theme-ui';
 import useProjects from '../../hooks/useProjects';
 import ProjectListItem from './ProjectListItem';
 
@@ -12,6 +12,11 @@ const styles: SXStyles = {
     gap: 8,
     flexDirection: 'column',
   },
+  error: {
+    alignSelf: 'center',
+    padding: '1rem 0',
+    color: 'red',
+  }
 };
 
 const ProjectsList = () => {
@@ -19,9 +24,9 @@ const ProjectsList = () => {
 
   return (
     <Flex sx={styles.root}>
-      {projects.length === 0 && !loading && '0 Projects'}
-      {projects.length === 0 && loading && 'Loading...'}
-      {error && 'Error loading projects'}
+      {!error && projects.length === 0 && !loading && '0 Projects'}
+      {!error && projects.length === 0 && loading && 'Loading...'}
+      {error && <Box sx={styles.error}>Error: Loading Projects</Box>}
       <Flex sx={styles.items}>
         {projects.map((project: ProjectType) => (
           <ProjectListItem


### PR DESCRIPTION
better error formatting

## Description

User should see more specific error in application error area
![image](https://user-images.githubusercontent.com/3970376/229564135-d6dcd817-a424-41f4-b4ac-c77042905816.png)




![image](https://user-images.githubusercontent.com/3970376/229563312-2f057d92-fb80-4387-af99-a299c413c5fa.png)



-- old
![image](https://user-images.githubusercontent.com/3970376/229563494-557f4008-a545-48a0-9ce9-8a5f778f59ca.png)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

