### PR TITLE
remove button to add account, not possible at this time

### DIFF
--- a/src/components/Editor/FileExplorer/AccountList.tsx
+++ b/src/components/Editor/FileExplorer/AccountList.tsx
@@ -120,7 +120,7 @@ const AccountList = ({ isExplorerCollapsed }: AccountListProps) => {
             setIsInserting(false);
           }}
         >
-          <ExplorerPlusIcon />
+          {/**<ExplorerPlusIcon />**/}
         </Button>
       </Flex>
       <Box data-test="account-list">

--- a/src/components/Editor/FileExplorer/AccountList.tsx
+++ b/src/components/Editor/FileExplorer/AccountList.tsx
@@ -2,7 +2,6 @@ import { navigate, useLocation } from '@reach/router';
 import { Account } from 'api/apollo/generated/graphql';
 import Avatar from 'components/Avatar';
 import Button from 'components/Button';
-import ExplorerPlusIcon from 'components/Icons/ExplorerPlusIcon';
 import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useState } from 'react';


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/632
Closes: https://github.com/onflow/flow-playground/issues/623

## Description

api doesn't support adding a new account, remove button

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

