### PR TITLE
add back in link to cadence language docs

### DIFF
--- a/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
@@ -23,7 +23,7 @@ const AccountPicker = ({
     if (max === 1) {
       // behave like radio button
       onChange([i]);
-    } 
+    }
     // all accounts selected
     const full = max === selectedAccounts.length;
     if (selectedAccounts.includes(i)) {

--- a/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/SignersPanel/AccountPicker.tsx
@@ -23,9 +23,13 @@ const AccountPicker = ({
     if (max === 1) {
       // behave like radio button
       onChange([i]);
-    } else if (selectedAccounts.includes(i)) {
+    } 
+    // all accounts selected
+    const full = max === selectedAccounts.length;
+    if (selectedAccounts.includes(i)) {
       onChange(selectedAccounts.filter((j: any) => j !== i));
     } else {
+      if (full) return;
       onChange([...selectedAccounts, i]);
     }
   };

--- a/src/components/TopNav/NavButtonLink.tsx
+++ b/src/components/TopNav/NavButtonLink.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import theme from '../../theme';
+import { SXStyles } from 'src/types';
+import { Link } from 'theme-ui';
+
+const styles: SXStyles = {
+  link: {
+    border: '1px solid #DEE2E9',
+    background: '#F6F7F9',
+    fontFamily: 'body',
+    color: 'text',
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    margin: 0,
+    fontWeight: 500,
+    padding: '0.25rem ',
+    borderRadius: '8px',
+    fontSize: 4,
+    '&:hover': {
+      background: `${theme.colors.menuBg}`,
+      borderColor: '#1E1FB9',
+    },
+  },
+};
+
+interface NavLinkProps {
+  href: string;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export const NavButtonLink = ({ href, title, children }: NavLinkProps) => {
+  return (
+    <Link
+      sx={styles.link}
+      rel="noreferrer"
+      variant="secondary"
+      title={title}
+      href={href}
+      target="_blank"
+    >
+      {children}
+    </Link>
+  );
+};

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -3,7 +3,7 @@ import Examples from 'components/Examples';
 import { useProject } from 'providers/Project/projectHooks';
 import React, { useEffect, useState } from 'react';
 import { SXStyles } from 'src/types';
-import { Flex, Link } from 'theme-ui';
+import { Flex } from 'theme-ui';
 import Mixpanel from 'util/mixpanel';
 import ProjectsIcon from 'components/Icons/ProjectsIcon';
 import LearnCadenceIcon from 'components/Icons/LearnCadenceIcon';
@@ -17,7 +17,6 @@ import {
 } from 'util/globalConstants';
 import { ExportButton } from './ExportButton';
 import GithubIcon from 'components/Icons/GithubIcon';
-import ExternalNavLinks from './TopNavButton';
 import { NavButtonLink } from './NavButtonLink';
 import { IconCadence } from 'components/Icons/CadenceIcon';
 

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -11,9 +11,15 @@ import NavInput from './NavInput';
 import { ShareMenu } from './ShareMenu';
 import { SaveButton } from './SaveButton';
 import theme from '../../theme';
-import { PLAYGROUND_GITHUB_ISSUES_URL } from 'util/globalConstants';
+import {
+  CADENCE_DOCS_URL,
+  PLAYGROUND_GITHUB_ISSUES_URL,
+} from 'util/globalConstants';
 import { ExportButton } from './ExportButton';
 import GithubIcon from 'components/Icons/GithubIcon';
+import ExternalNavLinks from './TopNavButton';
+import { NavButtonLink } from './NavButtonLink';
+import { IconCadence } from 'components/Icons/CadenceIcon';
 
 const styles: SXStyles = {
   root: {
@@ -132,16 +138,15 @@ const TopNav = () => {
               <LearnCadenceIcon />
               Learn Cadence
             </Button>
-            <Link
-              sx={styles.link}
-              rel="noreferrer"
-              variant="secondary"
+            <NavButtonLink
               title="Report a Bug"
               href={PLAYGROUND_GITHUB_ISSUES_URL}
-              target="_blank"
             >
               <GithubIcon />
-            </Link>
+            </NavButtonLink>
+            <NavButtonLink title="Cadence Docs" href={CADENCE_DOCS_URL}>
+              <IconCadence size="22px" title="Cadence Language Reference" />
+            </NavButtonLink>
             <ShareMenu />
             <ExportButton />
             <SaveButton />

--- a/src/util/globalConstants.ts
+++ b/src/util/globalConstants.ts
@@ -6,3 +6,5 @@ export const PLAYGROUND_GITHUB_ISSUES_URL =
   'https://github.com/onflow/flow-playground/issues/new/choose';
 
 export const HOTJAR_VERSION = 6;
+
+export const CADENCE_DOCS_URL = 'https://docs.onflow.org/cadence';


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/627
Closes: https://github.com/onflow/flow-playground/issues/579

## Description

Add top nav link to cadence docs
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

