### PR TITLE
disable loading last project

### DIFF
--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -121,19 +121,9 @@ interface PlaygroundProps extends RouteComponentProps {
 const Playground = ({ projectId }: PlaygroundProps) => {
   const userStorage = new UserLocalStorage();
   const isLocalProject = projectId === LOCAL_PROJECT_ID;
+  // disable saving last loaded project id
+  userStorage.setData(userDataKeys.PROJECT_ID, null);
 
-  if (!projectId) {
-    // get projectId if stored in localstorage
-    const projectId = userStorage.getDataByKey(userDataKeys.PROJECT_ID);
-    return (
-      <Redirect
-        noThrow
-        to={projectId ? `/${projectId}` : `/${LOCAL_PROJECT_ID}`}
-      />
-    );
-  } else if (projectId !== LOCAL_PROJECT_ID) {
-    userStorage.setData(userDataKeys.PROJECT_ID, projectId);
-  }
 
   return (
     <ProjectProvider urlProjectId={isLocalProject ? null : projectId}>

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -1,4 +1,4 @@
-import { Redirect, RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 import LeftSidebar from 'components/LeftSidebar';
 import { AnimatePresence, motion, MotionStyle } from 'framer-motion';
 import CadenceChecker from 'providers/CadenceChecker';
@@ -123,7 +123,6 @@ const Playground = ({ projectId }: PlaygroundProps) => {
   const isLocalProject = projectId === LOCAL_PROJECT_ID;
   // disable saving last loaded project id
   userStorage.setData(userDataKeys.PROJECT_ID, null);
-
 
   return (
     <ProjectProvider urlProjectId={isLocalProject ? null : projectId}>

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -176,6 +176,8 @@ export default class ProjectMutator {
     project.title = title || project.title;
     project.description = description || project.description;
     project.readme = readme || project.readme;
+    project.updatedAt = null;
+    project.contractDeployments = [];
 
     this.client.writeQuery({
       query: GET_PROJECT,


### PR DESCRIPTION


## Description

Remove loading last project. There is an issue of the backend can't load the project, UI gets in an infinite loop.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

