### PR TITLE
add load user's last project, rewrite url instead of redirecting

### DIFF
--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -92,7 +92,7 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
   const [problemsList, setProblemsList] = useState<any>({});
   const accountNumber = storageMapByIndex(active.index);
   // clear problems when new project is loaded
-  useEffect(() => setProblemsList({}), [project?.id])
+  useEffect(() => setProblemsList({}), [project?.id]);
   let fileName, script;
   switch (active.type) {
     case EntityType.ContractTemplate:

--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -3,7 +3,7 @@ import { Allotment } from 'allotment';
 import 'allotment/dist/style.css';
 import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import theme from '../../theme';
 import { SXStyles } from 'src/types';
 import { Box, Flex } from 'theme-ui';
@@ -91,6 +91,8 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
   const [selectedBottomTab, setSelectedBottomTab] = useState(0);
   const [problemsList, setProblemsList] = useState<any>({});
   const accountNumber = storageMapByIndex(active.index);
+  // clear problems when new project is loaded
+  useEffect(() => setProblemsList({}), [project?.id])
   let fileName, script;
   switch (active.type) {
     case EntityType.ContractTemplate:

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -127,16 +127,6 @@ const Playground = ({ projectId }: PlaygroundProps) => {
   const userProjectId = userStorage.getDataByKey(userDataKeys.PROJECT_ID);
   const loadingProjectId = projectId || userProjectId;
 
-  console.log(
-    'projectId',
-    'path',
-    location.pathname,
-    'id',
-    projectId,
-    'user',
-    userProjectId,
-  );
-
   let project: Project;
   let isLocal: boolean;
   let isLoading: boolean;

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -10,6 +10,7 @@ import useGetProject, { useProject } from 'providers/Project/projectHooks';
 import React, { CSSProperties } from 'react';
 import { Box, Button, Spinner, ThemeUICSSObject } from 'theme-ui';
 import { userDataKeys, UserLocalStorage } from 'util/localstorage';
+import { LOCAL_PROJECT_ID } from 'util/url';
 import useToggleExplorer from '../../hooks/useToggleExplorer';
 import EditorLayout from './EditorLayout';
 
@@ -126,6 +127,16 @@ const Playground = ({ projectId }: PlaygroundProps) => {
   const userProjectId = userStorage.getDataByKey(userDataKeys.PROJECT_ID);
   const loadingProjectId = projectId || userProjectId;
 
+  console.log(
+    'projectId',
+    'path',
+    location.pathname,
+    'id',
+    projectId,
+    'user',
+    userProjectId,
+  );
+
   let project: Project;
   let isLocal: boolean;
   let isLoading: boolean;
@@ -166,6 +177,7 @@ const Playground = ({ projectId }: PlaygroundProps) => {
         'Click <ok> to go to home page or last loaded project',
       ],
     };
+
     if (loadingProjectId === userProjectId) {
       // issue loading project clear last saved loaded project id
       userStorage.setData(userDataKeys.PROJECT_ID, null);
@@ -186,8 +198,10 @@ const Playground = ({ projectId }: PlaygroundProps) => {
     // update location to reflect project loaded
     window.history.replaceState({}, '', loadingProjectId);
   }
-  // project loaded successfully save as user's last project
-  userStorage.setData(userDataKeys.PROJECT_ID, loadingProjectId);
+  if (loadingProjectId !== LOCAL_PROJECT_ID) {
+    // project loaded successfully save as user's last project
+    userStorage.setData(userDataKeys.PROJECT_ID, loadingProjectId);
+  }
 
   return (
     <ProjectProvider project={project} isLocal={isLocal} client={client}>

--- a/src/hooks/useLanguageServer.ts
+++ b/src/hooks/useLanguageServer.ts
@@ -105,7 +105,7 @@ export default function useLanguageServer() {
     }
 
     restartServer();
-  }, []);
+  }, [project?.project?.id]);
 
   useEffect(() => {
     if (!languageClient) {

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -118,6 +118,14 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [currentEditor, setCurrentEditor] =
     useState<monacoEditor.ICodeEditor | null>(null);
 
+  const checkAppErrors = async () => {
+    await mutator.getApplicationErrors().then((res) => {
+      if (res?.errorMessage) {
+        setApplicationErrorMessage(res.errorMessage);
+      }
+    });
+  };
+
   useEffect(() => {
     if (showProjectsSidebar) {
       // close project sidebar if open and a different project gets loaded.
@@ -155,9 +163,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       navigate(`/${project.id}`, { replace: true });
     } catch (e) {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
+      checkAppErrors();
     }
     setIsSaving(false);
     setShowProjectsSidebar(false);
@@ -179,12 +185,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       }
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -194,13 +199,12 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     try {
       res = await mutator.saveProject(title, description, readme);
     } catch (e) {
+      console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
 
-    setIsSaving(false);
     return res;
   };
 
@@ -214,12 +218,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       }
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -246,13 +249,12 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       setLastSigners(signer);
     } catch (e) {
       console.error(e);
-      setIsSaving(false);
       setIsExecutingAction(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
+      checkAppErrors();
+    } finally {
+      setIsSaving(false);
     }
-    setIsSaving(false);
+
     setIsExecutingAction(false);
     return res;
   };
@@ -272,12 +274,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       template.title = title;
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -295,12 +296,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       contractTemplate.script = script;
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -318,12 +318,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       template.title = title;
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -343,12 +342,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       template.title = title;
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -365,12 +363,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       );
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -387,12 +384,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       );
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -421,13 +417,12 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     } catch (e) {
       console.error(e);
       setIsSaving(false);
+      checkAppErrors();
+    } finally {
+      setIsSaving(false);
       setIsExecutingAction(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
-    setIsExecutingAction(false);
+
     return res;
   };
 
@@ -442,14 +437,11 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       );
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
       setIsExecutingAction(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
-    setIsExecutingAction(false);
     return res;
   };
 
@@ -463,12 +455,10 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       res = await mutator.deleteContractTemplate(templateId);
     } catch (e) {
       console.error(e);
+      checkAppErrors();
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
     return res;
   };
 
@@ -482,12 +472,10 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       res = await mutator.deleteScriptTemplate(templateId);
     } catch (e) {
       console.error(e);
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 
@@ -501,12 +489,10 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
       res = await mutator.deleteTransactionTemplate(templateId);
     } catch (e) {
       console.error(e);
+    } finally {
       setIsSaving(false);
-      await mutator.getApplicationErrors().then((res) => {
-        setApplicationErrorMessage(res.errorMessage);
-      });
     }
-    setIsSaving(false);
+
     return res;
   };
 

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -71,7 +71,7 @@ export default function useGetProject(
   isClone: boolean;
   isLoading: boolean;
 } {
-  const isNewProject = projectId == null || projectId === LOCAL_PROJECT_ID;
+  const isNewProject = !projectId || projectId === LOCAL_PROJECT_ID;
 
   const { loading, data: remoteData } = useQuery(GET_PROJECT, {
     variables: { projectId: projectId },

--- a/src/providers/Project/projectHooks.ts
+++ b/src/providers/Project/projectHooks.ts
@@ -7,6 +7,7 @@ import { Project } from 'api/apollo/generated/graphql';
 import { ProjectContext, ProjectContextValue } from './index';
 import { createDefaultProject, createLocalProject } from './projectDefault';
 import { PROJECT_SERIALIZATION_KEY } from './projectMutator';
+import { LOCAL_PROJECT_ID } from 'util/url';
 
 function formatProject(project: Project) {
   if (!project) return project;
@@ -70,7 +71,7 @@ export default function useGetProject(
   isClone: boolean;
   isLoading: boolean;
 } {
-  const isNewProject = projectId == null;
+  const isNewProject = projectId == null || projectId === LOCAL_PROJECT_ID;
 
   const { loading, data: remoteData } = useQuery(GET_PROJECT, {
     variables: { projectId: projectId },


### PR DESCRIPTION
Closes: #622 
Closes: https://github.com/onflow/flow-playground/issues/638

## Description
 - load user's last successfully loaded project.
 - Fix issue when user refreshes '/local-project', UI tries to load as if saved project. 
 - Clear contract errors when user switches projects
 - Small clean up to reduce code
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

