### PR TITLE
fix conflict when site in maintenance and user has default project

### DIFF
--- a/src/containers/AppMobileWrapper.tsx
+++ b/src/containers/AppMobileWrapper.tsx
@@ -44,7 +44,9 @@ const AppMobileWrapper = ({ children }: ChildProps) => {
         visible={isInMaintenanceMode}
         {...infoInMaintenance}
       />
-      {!isInMaintenanceMode && <AppMobileWrapperDiv>{children}</AppMobileWrapperDiv>}
+      {!isInMaintenanceMode && (
+        <AppMobileWrapperDiv>{children}</AppMobileWrapperDiv>
+      )}
       <AppMobileWrapperMessageDiv>
         <Box
           sx={{

--- a/src/containers/AppMobileWrapper.tsx
+++ b/src/containers/AppMobileWrapper.tsx
@@ -44,7 +44,7 @@ const AppMobileWrapper = ({ children }: ChildProps) => {
         visible={isInMaintenanceMode}
         {...infoInMaintenance}
       />
-      <AppMobileWrapperDiv>{children}</AppMobileWrapperDiv>
+      {!isInMaintenanceMode && <AppMobileWrapperDiv>{children}</AppMobileWrapperDiv>}
       <AppMobileWrapperMessageDiv>
         <Box
           sx={{


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/655

## Description

Don't load project when in maintenance mode
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

