### PR TITLE
add ability to copy existing project

### DIFF
--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -15,6 +15,7 @@ import InformationalPopup from 'components/InformationalPopup';
 import { LOCAL_PROJECT_ID } from 'util/url';
 import CopyIcon from 'components/Icons/CopyIcon';
 import { Project } from 'api/apollo/generated/graphql';
+import { userDataKeys, UserLocalStorage } from 'util/localstorage';
 
 type Props = {
   project: ProjectType;
@@ -86,6 +87,7 @@ const willLoseChangesOptions = {
 };
 
 const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
+  const userStorage = new UserLocalStorage();
   const [doingAction, setDoingAction] = useState<boolean>(false);
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
   const [showLastProject, setShowLastProject] = useState<boolean>(false);
@@ -103,6 +105,10 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
     if (isConfirmed) {
       setDoingAction(true);
       try {
+        // update user's local storage if deleting active project
+        if (activeProject.id === project.id) {
+          userStorage.setData(userDataKeys.PROJECT_ID, null);
+        }
         await deleteProject(project.id);
         await refetch();
       } finally {

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -5,7 +5,7 @@ import {
   Project,
 } from 'api/apollo/generated/graphql';
 import React, { createContext, useEffect, useState } from 'react';
-import { ChildProps, Template } from 'src/types';
+import { ChildProps, ProjectType, Template } from 'src/types';
 import { getParams, LOCAL_PROJECT_ID } from 'util/url';
 import ProjectMutator from './projectMutator';
 import { storageMapByAddress } from 'util/accounts';
@@ -31,6 +31,7 @@ export interface ProjectContextValue {
   isLoading: boolean;
   mutator: ProjectMutator;
   createBlankProject: () => Promise<Project>;
+  copyProject: (project: Project) => Promise<Project>;
   updateProject: (
     title: string,
     description: string,
@@ -157,6 +158,21 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     description,
     readme,
   );
+
+  const copyProject = async (project: Project) => {
+    setIsSaving(true);
+    let res;
+    try {
+      // create default project and save to cache
+      res = mutator.createProjectCopy(project);
+      // refresh project list
+    } catch (e) {
+      checkAppErrors();
+    } finally {
+      setIsSaving(false);
+    }
+    return res;
+  };
 
   const createBlankProject = async () => {
     setIsSaving(true);
@@ -781,6 +797,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         isSaving,
         isExecutingAction,
         createBlankProject,
+        copyProject,
         updateProject,
         saveProject,
         deleteProject,

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -5,7 +5,7 @@ import {
   Project,
 } from 'api/apollo/generated/graphql';
 import React, { createContext, useEffect, useState } from 'react';
-import { ChildProps, ProjectType, Template } from 'src/types';
+import { ChildProps, Template } from 'src/types';
 import { getParams, LOCAL_PROJECT_ID } from 'util/url';
 import ProjectMutator from './projectMutator';
 import { storageMapByAddress } from 'util/accounts';

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -234,7 +234,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     try {
       res = await mutator.deleteProject(dProjectId);
       if (projectId === dProjectId) {
-        navigate(`/`);
+        navigate(`/${LOCAL_PROJECT_ID}`, { replace: true });
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/348

## Description
Give user ability to duplicate an existing project (copy a project)
Also, fixed minor bug, when user deletes active project and the deleted project is stored as user's last project. UI will try to load deleted project.

![2023-05-02 15 50 55](https://user-images.githubusercontent.com/3970376/235783100-6a147e98-e790-468b-b3e1-27fe1d9f0dac.gif)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

