### PR TITLE
inform user they have dup file names

### DIFF
--- a/src/components/Editor/CadenceEditor/ControlPanel/utils.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/utils.tsx
@@ -138,3 +138,16 @@ export const getAccountContract = (
   // TODO: need to get contract name to work, only works if account has one contract deployed
   return deployed?.script || null;
 };
+
+export const hasDuplicates = (array: string[]) => {
+  return new Set(array).size !== array.length;
+};
+
+export const findDuplicateIndex = (array: string[]): number => {
+  for (let i = 0; i < array.length; i++) {
+    if (array.indexOf(array[i]) !== array.lastIndexOf(array[i])) {
+      return i;
+    }
+  }
+  return -1;
+};

--- a/src/components/Editor/FileExplorer/ExplorerInput.tsx
+++ b/src/components/Editor/FileExplorer/ExplorerInput.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import theme from '../../../theme';
 import { SXStyles } from 'src/types';
 import { Input as ThemeUiInput } from 'theme-ui';
 
@@ -10,6 +11,7 @@ interface InputProps {
   index: number;
   editing: Array<number>;
   toggleEditing: any;
+  hasError?: boolean;
 }
 
 const styles: SXStyles = {
@@ -23,7 +25,7 @@ const styles: SXStyles = {
     pointerEvents: 'initial',
     background: '#FFFFFF',
     fontFamily: 'inherit',
-    borderRadius: '4px',
+    borderRadius: '8px',
   },
   inputReadOnly: {
     width: '100%',
@@ -35,6 +37,11 @@ const styles: SXStyles = {
     background: 'none',
     pointerEvents: 'none',
     fontFamily: 'inherit',
+    borderRadius: '8px',
+  },
+  hasError: {
+    borderColor: theme.colors.errorBackground,
+    background: theme.colors.errorBackground,
   },
 };
 
@@ -46,11 +53,15 @@ const Input = ({
   index,
   editing,
   toggleEditing,
+  hasError = false,
 }: InputProps) => {
   const ref = useRef(null);
   const [isEditing, setIsEditing] = useState(false);
   const isEditingParent = editing.includes(index);
-  const inputStyle = isEditingParent ? styles.input : styles.inputReadOnly;
+  const inputStyle = {
+    ...(isEditingParent ? styles.input : styles.inputReadOnly),
+    ...(hasError ? styles.hasError : null),
+  };
   const MAX_LENGTH = 50;
 
   useEffect(() => {

--- a/src/components/Editor/FileExplorer/FilesList.tsx
+++ b/src/components/Editor/FileExplorer/FilesList.tsx
@@ -4,8 +4,8 @@ import ExplorerScriptIcon from 'components/Icons/ExplorerScriptIcon';
 import ExplorerTransactionIcon from 'components/Icons/ExplorerTransactionIcon';
 import { EntityType } from 'providers/Project';
 import { useProject } from 'providers/Project/projectHooks';
-import React, { useState } from 'react';
-import { ChildProps, SXStyles } from 'src/types';
+import React, { useEffect, useState } from 'react';
+import { ChildProps, SXStyles, Template } from 'src/types';
 import { Box, Flex } from 'theme-ui';
 import MenuList from './MenuList';
 import InformationalPopup from '../../InformationalPopup';
@@ -14,6 +14,8 @@ import {
   UrlRewritterWithId,
   FILE_TYPE_NAME,
 } from 'util/urlRewritter';
+import { hasDuplicates } from '../CadenceEditor/ControlPanel/utils';
+import { ResultType } from 'api/apollo/generated/graphql';
 
 type FileListProps = {
   isExplorerCollapsed: boolean;
@@ -72,6 +74,20 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
     return <Box sx={isSelected ? styles.selected : {}}>{children}</Box>;
   };
 
+  const handelDupNames = (type: ResultType, names: string[]) => {
+    console.log('testing names', names);
+    if (hasDuplicates(names)) {
+      setApplicationErrorMessage(
+        `${type.toLowerCase()} file name already exists`,
+      );
+    }
+  };
+
+  const getNames = (items: Template[]) => {
+    return items?.map((template) => {
+      return template.title;
+    });
+  };
   const handleDelete = async ({
     itemType,
     templateId,
@@ -129,6 +145,16 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
       );
     }
 
+    const contractNames = getNames(project.contractTemplates);
+    const transactionNames = getNames(project.transactionTemplates);
+    const scriptNames = getNames(project.scriptTemplates);
+
+    useEffect(() => {
+      handelDupNames(ResultType.Contract, contractNames);
+      handelDupNames(ResultType.Transaction, transactionNames);
+      handelDupNames(ResultType.Script, scriptNames);
+    }, [contractNames, transactionNames, scriptNames]);
+
     return (
       <>
         <Flex sx={styles.header}>FILES</Flex>
@@ -136,9 +162,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
           title="Contracts"
           itemType={EntityType.ContractTemplate}
           items={project.contractTemplates}
-          itemTitles={project.contractTemplates?.map((template) => {
-            return template.title;
-          })}
+          itemTitles={contractNames}
           onSelect={(_, id) => {
             navigate(UrlRewritterWithId(project, FILE_TYPE_NAME.contract, id));
           }}
@@ -168,9 +192,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
           title="Transactions"
           itemType={EntityType.TransactionTemplate}
           items={project.transactionTemplates}
-          itemTitles={project.transactionTemplates?.map((template) => {
-            return template.title;
-          })}
+          itemTitles={transactionNames}
           onSelect={(_, id) => {
             navigate(
               UrlRewritterWithId(project, FILE_TYPE_NAME.transaction, id),
@@ -205,9 +227,7 @@ const FilesList = ({ isExplorerCollapsed }: FileListProps) => {
           title="Scripts"
           itemType={EntityType.ScriptTemplate}
           items={project.scriptTemplates}
-          itemTitles={project.scriptTemplates?.map((template) => {
-            return template.title;
-          })}
+          itemTitles={scriptNames}
           onSelect={(_, id) => {
             navigate(UrlRewritterWithId(project, FILE_TYPE_NAME.script, id));
           }}


### PR DESCRIPTION
References: #348 

## Description

Inform the user they have duplicate file names during editing a files and
on project load.

![2023-05-03 14 39 22](https://user-images.githubusercontent.com/3970376/236027981-c8c5cf1f-79c6-4802-9a02-507678365765.gif)




![2023-05-03 14 39 53](https://user-images.githubusercontent.com/3970376/236027958-76c50fb9-8b9a-4496-a309-72e61c359772.gif)



For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

