### PR TITLE
Make duplicate name highlight refresh when files deleted

### DIFF
--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -190,6 +190,7 @@ const MenuList: React.FC<MenuListProps> = ({
   };
 
   useEffect(() => {
+    setIndexHasError(-1);
     setItemNames(itemTitles);
     if (hasDuplicates(itemTitles)) {
       setIndexHasError(findDuplicateIndex(itemTitles));


### PR DESCRIPTION
Closes: #681

 Changed line in MenuList.tsx fixes the red highlight not refreshing when contract deleted

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

