### PR TITLE
get contract init parameters

### DIFF
--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -121,15 +121,21 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
    * Sends request to langugeClient to get entry point parameters.
    * @return Promise which resolved to a list of arguments
    */
-  const getParameters = async (): Promise<[any?]> => {
+  const getParameters = async (
+    isContract: boolean = false,
+  ): Promise<[any?]> => {
     if (!languageClient) {
+      console.error('lauguageClient is not initialized');
       return [];
     }
+    const command = isContract
+      ? 'cadence.server.getContractInitializerParameters'
+      : 'cadence.server.getEntryPointParameters';
     try {
       const args = await languageClient.sendRequest(
         ExecuteCommandRequest.type,
         {
-          command: 'cadence.server.getEntryPointParameters',
+          command,
           arguments: [editor.getModel().uri.toString()],
         },
       );
@@ -191,7 +197,9 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
       CadenceCheckCompleted.methodName,
       async (result: CadenceCheckCompleted.Params) => {
         if (result.valid) {
-          const params = await getParameters();
+          const params = await getParameters(
+            active.type == EntityType.ContractTemplate,
+          );
           const key = getActiveKey();
 
           // Update state


### PR DESCRIPTION
Still needs work. 
Waiting on feedback from cadence tools on this Issue https://github.com/onflow/cadence-tools/issues/129

## Description

Blocked by: https://github.com/onflow/cadence-tools/issues/129


get contract init parameters and allow user to input

![image](https://github.com/onflow/flow-playground/assets/3970376/84d59e17-8372-4df0-b8fb-b3345b43d7ce)

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

