### PR TITLE
add cadence root folder for files for export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "webpack-dev-server": "^4.11.1"
       },
       "engines": {
-        "node": ">=16.0.0 <=18.8.0"
+        "node": "18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow-playground",
   "private": true,
   "engines": {
-    "node": ">=16.0.0 <=18.8.0"
+    "node": "18.x"
   },
   "scripts": {
     "start": "webpack-dev-server -d source-map --config webpack.config.js",

--- a/src/components/TopNav/ExportButton.tsx
+++ b/src/components/TopNav/ExportButton.tsx
@@ -47,15 +47,16 @@ export const ExportButton = () => {
     if (!isDownload) return;
 
     const zip = new JSZip();
-    const contracts = zip.folder('contracts');
+    const cadence = zip.folder('cadence');
+    const contracts = cadence.folder('contracts');
     project.contractTemplates.map((cdc) =>
       contracts.file(`${cdc.title}.cdc`, cdc.script),
     );
-    const scripts = zip.folder('scripts');
+    const scripts = cadence.folder('scripts');
     project.scriptTemplates.map((script) =>
       scripts.file(`${script.title}.cdc`, script.script),
     );
-    const transactions = zip.folder('transactions');
+    const transactions = cadence.folder('transactions');
     project.transactionTemplates.map((tx) =>
       transactions.file(`${tx.title}.cdc`, tx.script),
     );

--- a/src/providers/Project/projectDefault.ts
+++ b/src/providers/Project/projectDefault.ts
@@ -138,7 +138,7 @@ const DEFAULT_SCRIPT = `pub fun main(): Int {
 }
 `;
 
-export const SEED_TITLE = 'Cadence Playground';
+export const SEED_TITLE = 'Untitled Project';
 export const SEED_DESCRIPTION = 'Showcase Cadence interactions';
 export const SEED_README = '';
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/696
Closes: https://github.com/onflow/flow-playground/issues/484
Closes: https://github.com/onflow/flow-playground/issues/317

## Description
 - upgrade to use node v18, works with 5.x version of webpack
 - Rename default project title to Untiled Project
 - To get ready for adding flow.json that is generated from api put all files in a cadence folder. This also conforms to "flow dev" cli command folder structure.

![image](https://github.com/onflow/flow-playground/assets/3970376/5586c9af-2a5d-427e-b823-bd4e048fe4e6)



______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

