### PR TITLE
instead of disabling playground in mobile mode, create a read only mode

### DIFF
--- a/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
+++ b/src/components/Editor/BottomEditorPanel/BottomEditorPanelHeader.tsx
@@ -7,6 +7,7 @@ import { SXStyles } from 'src/types';
 import { Box, Flex } from 'theme-ui';
 import Button from '../../Button';
 import LogIcon from '../../Icons/LogIcon';
+import theme from '../../../theme';
 
 type BottomEditorPanelHeaderProps = {
   problems: any;
@@ -104,6 +105,10 @@ const BottomEditorPanelHeader = ({
       ? 's'
       : ''
   }`;
+
+  if (theme.isMobile) {
+    return null;
+  }
 
   return (
     <Flex as={Tab.List} sx={styles.header}>

--- a/src/components/Editor/BottomEditorPanel/index.tsx
+++ b/src/components/Editor/BottomEditorPanel/index.tsx
@@ -6,6 +6,7 @@ import { Flex } from 'theme-ui';
 import BottomEditorPanelHeader from './BottomEditorPanelHeader';
 import RenderError from './RenderError';
 import { RenderResponse } from './RenderResponse';
+import theme from '../../../theme';
 
 export const BOTTOM_EDITOR_PANEL_HEADER_HEIGHT = 80;
 
@@ -62,6 +63,10 @@ const BottomEditorPanel = ({
     );
   };
   const panelProblems = getProblems();
+
+  if (theme.isMobile) {
+    return null;
+  }
 
   return (
     <Flex sx={styles.root}>

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -57,6 +57,7 @@ import { Template } from 'src/types';
 import DismissiblePopup from 'components/DismissiblePopup';
 import { userModalKeys } from 'util/localstorage';
 import { addressToAccount } from 'util/accounts';
+import theme from '../../../../theme';
 
 const ButtonActionLabels = {
   [String(EntityType.TransactionTemplate)]: 'Send',
@@ -472,7 +473,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     validate(list, values);
   }, [list, values]);
 
-  if (type === EntityType.AccountStorage) {
+  if (type === EntityType.AccountStorage || theme.isMobile) {
     return null;
   }
 

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -7,6 +7,7 @@ import { EditorContainer } from './components';
 import ControlPanel from './ControlPanel';
 import { EditorState } from './types';
 import { EntityType } from 'providers/Project';
+import theme from '../../../theme';
 
 const MONACO_CONTAINER_ID = 'monaco-container';
 
@@ -76,7 +77,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
       if (editorOnChange.current) {
         editorOnChange.current.dispose();
       }
-      if (project.active.type === EntityType.AccountStorage) {
+      if (project.active.type === EntityType.AccountStorage || theme.isMobile) {
         editor.updateOptions({ readOnly: true });
       } else {
         editor.updateOptions({ readOnly: false });

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -33,6 +33,16 @@ const styles: SXStyles = {
     paddingLeft: '1em',
     paddingRight: '1em',
   },
+  mobile: {
+    background: 'white',
+    display: 'flex',
+    gridArea: 'header',
+    flex: '1 1 auto',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: '1rem',
+  },
   button: {
     border: '1px solid #DEE2E9',
     borderRadius: '8px',
@@ -102,6 +112,18 @@ const TopNav = () => {
     setProjectName(project.title);
   }, [project?.id]);
 
+  if (theme.isMobile) {
+    return (
+      <Flex sx={styles.mobile}>
+        <NavInput
+          type="text"
+          value={projectName}
+          onChange={() => {}}
+          updateValue={() => {}}
+        />
+      </Flex>
+    );
+  }
   return (
     <Flex sx={styles.root}>
       <Flex sx={styles.topNavSection}>

--- a/src/containers/AppMobileWrapper.tsx
+++ b/src/containers/AppMobileWrapper.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import InformationalPopup from 'components/InformationalPopup';
 import React from 'react';
 import { ChildProps } from 'src/types';
-import { Box, Button, Text } from 'theme-ui';
+import theme from '../theme';
 
 const isInMaintenanceMode = process.env.IS_IN_MAINTENANCE === 'true';
 const infoInMaintenance = {
@@ -16,24 +16,21 @@ const infoInMaintenance = {
 const AppMobileWrapperDiv = styled.div`
   display: block;
   position: relative;
-  @media only screen and (max-width: 1079px) {
-    display: none;
-  }
 `;
 
-const AppMobileWrapperMessageDiv = styled.div`
-  display: flex;
-  padding: 2rem;
-  height: 100vh;
+const StyledReadOnly = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  height: 16px;
+  background: ${theme.colors.leftSidebarBackground};
+  color: ${theme.colors.text};
+  font-size: 12px;
+  font-weight: 500;
   text-align: center;
-
-  @media only screen and (min-width: 1080px) {
-    display: none;
-  }
+  padding: 2px 0;
+  z-index: 100;
 `;
 
 const AppMobileWrapper = ({ children }: ChildProps) => {
@@ -44,36 +41,10 @@ const AppMobileWrapper = ({ children }: ChildProps) => {
         visible={isInMaintenanceMode}
         {...infoInMaintenance}
       />
+      {theme.isMobile && <StyledReadOnly>Read Only Mode</StyledReadOnly>}
       {!isInMaintenanceMode && (
         <AppMobileWrapperDiv>{children}</AppMobileWrapperDiv>
       )}
-      <AppMobileWrapperMessageDiv>
-        <Box
-          sx={{
-            marginBottom: '2rem',
-          }}
-        >
-          <img src="/flow_logo.jpg" alt="Flow Logo" width="160" height="160" />
-        </Box>
-        <Text
-          sx={{
-            marginBottom: '4rem',
-            fontSize: '2rem',
-            fontWeight: 'bold',
-          }}
-        >
-          The Flow Playground is best used on larger screens.
-        </Text>
-        <Box>
-          <Button
-            onClick={() => {
-              window.location.href = 'https://www.onflow.org';
-            }}
-          >
-            Visit Flow&apos;s Website
-          </Button>
-        </Box>
-      </AppMobileWrapperMessageDiv>
     </>
   );
 };

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -52,7 +52,7 @@ const getBaseStyles = (
     display: 'grid',
     gridTemplateAreas: "'header header' 'sidebar main'",
     gridTemplateColumns: `${fileExplorerWidth} auto`,
-    gridTemplateRows: '50px auto',
+    gridTemplateRows: ['40px auto', '50px auto'],
     overflow: 'hidden',
     filter: showProjectsSidebar ? 'blur(1px)' : 'none',
   };

--- a/src/hooks/useToggleExplorer.ts
+++ b/src/hooks/useToggleExplorer.ts
@@ -1,7 +1,10 @@
 import { useState } from 'react';
+import theme from '../theme';
 
 function useToggleExplorer() {
-  const [isExplorerCollapsed, setIsExplorerCollapsed] = useState(false);
+  const [isExplorerCollapsed, setIsExplorerCollapsed] = useState(
+    theme.isMobile,
+  );
 
   const toggleExplorer = () => {
     setIsExplorerCollapsed(!isExplorerCollapsed);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,5 @@
 export default {
+  isMobile: window.matchMedia('(max-width: 768px)')?.matches,
   colors: {
     white: '#ffffff',
     black: '#000000',


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/441

## Description

Allow users to see playground projects on mobile. It would be read-only but users would get to share and see projects via mobile. 

![2023-06-14 12 56 10](https://github.com/onflow/flow-playground/assets/3970376/71e02122-8728-4858-a41b-c7dfcb3cbfa0)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

