### PR TITLE
mobile style clean up

### DIFF
--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -154,6 +154,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
       readOnly:
         project.active.type === EntityType.AccountStorage || theme.isMobile,
       domReadOnly: theme.isMobile,
+      contextmenu: !theme.isMobile,
     });
 
     const [code] = project.getActiveCode();

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -151,7 +151,9 @@ const CadenceEditor = (props: CadenceEditorProps) => {
       minimap: {
         enabled: false,
       },
-      readOnly: project.active.type === EntityType.AccountStorage,
+      readOnly:
+        project.active.type === EntityType.AccountStorage || theme.isMobile,
+      domReadOnly: theme.isMobile,
     });
 
     const [code] = project.getActiveCode();

--- a/src/components/Editor/FileExplorer/MenuList.tsx
+++ b/src/components/Editor/FileExplorer/MenuList.tsx
@@ -233,7 +233,7 @@ const MenuList: React.FC<MenuListProps> = ({
             <ExplorerFileShutterIcon />
           </Button>
         </Flex>
-        {!!onInsert && (
+        {!!onInsert && !theme.isMobile && (
           <Button
             inline={true}
             sx={styles.button}

--- a/src/components/Editor/FileExplorer/index.tsx
+++ b/src/components/Editor/FileExplorer/index.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { SXStyles } from 'src/types';
 import { Flex } from 'theme-ui';
 import FilesList from './FilesList';
+import theme from '../../../theme';
 
 type FileExplorerProps = {
   isExplorerCollapsed: boolean;
@@ -42,6 +43,7 @@ const styles: SXStyles = {
     borderRadius: '8px',
   },
   shutterClosed: {
+    left: theme.isMobile ? '10px' : '20px',
     position: 'absolute',
     padding: '0px',
     borderRadius: '8px',

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -13,6 +13,7 @@ import { userDataKeys, UserLocalStorage } from 'util/localstorage';
 import { LOCAL_PROJECT_ID } from 'util/url';
 import useToggleExplorer from '../../hooks/useToggleExplorer';
 import EditorLayout from './EditorLayout';
+import theme from '../../theme';
 
 export const LEFT_SIDEBAR_WIDTH = 350;
 
@@ -40,7 +41,11 @@ const getBaseStyles = (
   showProjectsSidebar: boolean,
   isExplorerCollapsed: boolean,
 ): ThemeUICSSObject => {
-  const fileExplorerWidth = isExplorerCollapsed ? '65px' : '244px';
+  const fileExplorerWidth = isExplorerCollapsed
+    ? theme.isMobile
+      ? '30px'
+      : '65px'
+    : '244px';
 
   const styles: ThemeUICSSObject = {
     position: 'absolute',
@@ -51,7 +56,7 @@ const getBaseStyles = (
     height: '100vh',
     display: 'grid',
     gridTemplateAreas: "'header header' 'sidebar main'",
-    gridTemplateColumns: `${fileExplorerWidth} auto`,
+    gridTemplateColumns: `[sidebar] ${fileExplorerWidth} [main] auto`,
     gridTemplateRows: ['40px auto', '50px auto'],
     overflow: 'hidden',
     filter: showProjectsSidebar ? 'blur(1px)' : 'none',

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <!-- Welcome to the Flow Playground -->
     <title lang="en">Flow Playground</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="title" content="Try out this Playground project" />
     <meta
       name="description"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,5 @@
 export default {
+  breakpoints: ['576px', '768px', '992px'],
   isMobile: window.matchMedia('(max-width: 768px)')?.matches,
   colors: {
     white: '#ffffff',


### PR DESCRIPTION
## Description
 - added breakpoints to take advantage of themeUI syntax, future use.
 - style collapsed file menu
 - remove "+" since files can not be created
![image](https://github.com/onflow/flow-playground/assets/3970376/85ec7aa3-690f-47ae-a037-f73311e7801a)

 - fixed readonly of textarea so that context menu does not come up, also so that keyboard does not come up on mobile
![image](https://github.com/onflow/flow-playground/assets/3970376/04ffcd58-753d-4dae-b8fb-e3f68313d485)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

