### PR TITLE
add url syntax for editor line highlighting

### DIFF
--- a/src/components/Editor/BottomEditorPanel/RenderResponse/index.tsx
+++ b/src/components/Editor/BottomEditorPanel/RenderResponse/index.tsx
@@ -35,18 +35,21 @@ export const RenderResponse = () => {
   const filteredResults = resultType
     ? data.cachedExecutionResults[resultType]
     : [];
+  const formattedFilteredResults = filteredResults
+    .slice(0)
+    .map((line: LineType, index: number) => ({ ...line, index }))
+    .reverse();
 
-  const formattedFilteredResults = filteredResults.slice(0).map((line: LineType, index: number) => ({...line, index})).reverse()
-  
   return (
     <Flex sx={styles.root} data-test="execution-results">
       {filteredResults.length > 0
         ? !loading &&
           !error &&
-          formattedFilteredResults
-            .map((formattedLine: LineType & {key: string, index: number}) => (
+          formattedFilteredResults.map(
+            (formattedLine: LineType & { key: string; index: number }) => (
               <Line {...formattedLine} key={JSON.stringify(formattedLine)} />
-            ))
+            ),
+          )
         : 'Welcome to the Playground!'}
     </Flex>
   );

--- a/src/components/Editor/BottomEditorPanel/RenderResponse/index.tsx
+++ b/src/components/Editor/BottomEditorPanel/RenderResponse/index.tsx
@@ -36,17 +36,17 @@ export const RenderResponse = () => {
     ? data.cachedExecutionResults[resultType]
     : [];
 
+  const formattedFilteredResults = filteredResults.slice(0).map((line: LineType, index: number) => ({...line, index})).reverse()
+  
   return (
     <Flex sx={styles.root} data-test="execution-results">
       {filteredResults.length > 0
         ? !loading &&
           !error &&
-          filteredResults
-            .reverse()
-            .map((line: LineType, n: number) => (
-              <Line {...line} key={n} index={n} />
+          formattedFilteredResults
+            .map((formattedLine: LineType & {key: string, index: number}) => (
+              <Line {...formattedLine} key={JSON.stringify(formattedLine)} />
             ))
-            .reverse()
         : 'Welcome to the Playground!'}
     </Flex>
   );

--- a/src/components/Editor/CadenceEditor/components.tsx
+++ b/src/components/Editor/CadenceEditor/components.tsx
@@ -81,4 +81,9 @@ export const EditorContainer = styled.div<EditorContainerProps>`
     border-radius: 3px;
     animation: ${blink} 1s ease-in-out infinite;
   }
+
+  .playground-syntax-hightlight-hover-selection {
+    background-color: rgb(238, 169, 30, 0.3);
+    border-radius: 3px;
+  }
 `;

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -8,6 +8,7 @@ import ControlPanel from './ControlPanel';
 import { EditorState } from './types';
 import { EntityType } from 'providers/Project';
 import theme from '../../../theme';
+import { hightlightLines } from 'util/language-syntax-errors';
 
 const MONACO_CONTAINER_ID = 'monaco-container';
 
@@ -116,6 +117,10 @@ const CadenceEditor = (props: CadenceEditorProps) => {
         editor.restoreViewState(newState.viewState);
         editor.focus();
         editor.layout();
+        if (project.hightlightedLines.length > 0) {
+          console.log('hightlightLines', project.hightlightedLines);
+          hightlightLines(editor, project.hightlightedLines);
+        }
       }
       editorOnChange.current = editor.onDidChangeModelContent(() => {
         if (project.project?.accounts) {
@@ -159,6 +164,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
 
     const [code] = project.getActiveCode();
     const model = monaco.editor.createModel(code, CADENCE_LANGUAGE_ID);
+
     const state: EditorState = {
       model,
       viewState: null,

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -118,7 +118,6 @@ const CadenceEditor = (props: CadenceEditorProps) => {
         editor.focus();
         editor.layout();
         if (project.hightlightedLines.length > 0) {
-          console.log('hightlightLines', project.hightlightedLines);
           hightlightLines(editor, project.hightlightedLines);
         }
       }

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -6,7 +6,7 @@ import {
 } from 'api/apollo/generated/graphql';
 import React, { createContext, useEffect, useState } from 'react';
 import { ChildProps, Template } from 'src/types';
-import { getParams, LOCAL_PROJECT_ID } from 'util/url';
+import { getHashLineNumber, getParams, LOCAL_PROJECT_ID } from 'util/url';
 import ProjectMutator from './projectMutator';
 import { storageMapByAddress } from 'util/accounts';
 import { editor as monacoEditor } from 'monaco-editor/esm/vs/editor/editor.api';
@@ -90,6 +90,7 @@ export interface ProjectContextValue {
   clearApplicationErrors: () => void;
   setCurrentEditor: (editor: monacoEditor.ICodeEditor) => void;
   currentEditor: monacoEditor.ICodeEditor | null;
+  hightlightedLines: number[];
 }
 
 export const ProjectContext: React.Context<ProjectContextValue> =
@@ -122,6 +123,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
   const [applicationErrorMessage, setApplicationErrorMessage] = useState('');
   const [currentEditor, setCurrentEditor] =
     useState<monacoEditor.ICodeEditor | null>(null);
+  const hightlightedLines: number[] = getHashLineNumber();
 
   const checkAppErrors = async () => {
     await mutator.getApplicationErrors().then((res) => {
@@ -848,6 +850,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         clearApplicationErrors,
         setCurrentEditor,
         currentEditor,
+        hightlightedLines,
       }}
     >
       {children}

--- a/src/util/language-syntax-errors.ts
+++ b/src/util/language-syntax-errors.ts
@@ -153,3 +153,20 @@ export const hideDecorations = (editor: monacoEditor.ICodeEditor): void => {
 
   model.deltaDecorations(current, []);
 };
+
+export const hightlightLines = (
+  editor: monacoEditor.ICodeEditor,
+  lines: number[],
+): void => {
+  const [startLine, endLine] = lines.length > 1 ? lines : [lines[0], lines[0]];
+  const range = new Range(startLine, 1, endLine, 1);
+  const op = {
+    range,
+    options: {
+      isWholeLine: true,
+      className: 'playground-syntax-hightlight-hover-selection',
+    },
+  };
+
+  editor.getModel().deltaDecorations([], [op]);
+};

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -14,6 +14,18 @@ export const getParams = (url: string): any => {
     }, {});
 };
 
+export const getHashLineNumber = (): number[] => {
+  const value = window.location.hash?.substring(1);
+  if (!value) return [];
+
+  const lineNumbers = value.substring(1);
+  if (lineNumbers.includes('-')) {
+    const [start, end] = lineNumbers.replace('L', '').split('-');
+    return [Number(start), Number(end)];
+  }
+  return [Number(lineNumbers)];
+};
+
 export const scriptTypes = ['contract', 'tx', 'script'];
 
 export const LOCAL_PROJECT_ID = 'local-project';

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -18,9 +18,9 @@ export const getHashLineNumber = (): number[] => {
   const value = window.location.hash?.substring(1);
   if (!value) return [];
 
-  const lineNumbers = value.substring(1);
+  const lineNumbers = value.toLocaleUpperCase().replace('L', '');
   if (lineNumbers.includes('-')) {
-    const [start, end] = lineNumbers.replace('L', '').split('-');
+    const [start, end] = lineNumbers.split('-');
     return [Number(start), Number(end)];
   }
   return [Number(lineNumbers)];


### PR DESCRIPTION
Closes: #129 

## Description

adding hash parameter to highlight code `#L3-L5` gives this effect. 

![image](https://github.com/onflow/flow-playground/assets/3970376/334bd097-e9f6-49cb-b92a-59ae367b0d1f)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

