### PR TITLE
add context menu item to build selection url

### DIFF
--- a/src/components/Editor/CadenceEditor/EditorCustomActions.tsx
+++ b/src/components/Editor/CadenceEditor/EditorCustomActions.tsx
@@ -1,0 +1,30 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { buildHashUrl } from 'util/url';
+
+export const addCustomActions = (
+  editorRef: monaco.editor.IStandaloneCodeEditor,
+) => {
+  // Adding custom action to the context menu
+  editorRef.addAction({
+    id: 'my-unique-action-id',
+    label: 'Copy Highlight Link',
+    contextMenuGroupId: '9_cutcopypaste', // Add to navigation group
+    contextMenuOrder: 10.5, // Control the order in the context menu
+    run: function (ed: any) {
+      const selection = ed.getSelection();
+      if (selection) {
+        const { startLineNumber, endLineNumber } = selection;
+        const newUrl = buildHashUrl([
+          ...new Set([startLineNumber, endLineNumber]),
+        ]);
+        copyToClipboard(newUrl);
+      }
+    },
+  });
+};
+
+function copyToClipboard(data: string) {
+  navigator.clipboard.writeText(data).catch((err) => {
+    console.error('Could not copy URL to clipboard', err);
+  });
+}

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -9,6 +9,7 @@ import { EditorState } from './types';
 import { EntityType } from 'providers/Project';
 import theme from '../../../theme';
 import { hightlightLines } from 'util/language-syntax-errors';
+import { addCustomActions } from './EditorCustomActions';
 
 const MONACO_CONTAINER_ID = 'monaco-container';
 
@@ -120,6 +121,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
         if (project.hightlightedLines.length > 0) {
           hightlightLines(editor, project.hightlightedLines);
         }
+        addCustomActions(editor);
       }
       editorOnChange.current = editor.onDidChangeModelContent(() => {
         if (project.project?.accounts) {

--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -121,7 +121,6 @@ const CadenceEditor = (props: CadenceEditorProps) => {
         if (project.hightlightedLines.length > 0) {
           hightlightLines(editor, project.hightlightedLines);
         }
-        addCustomActions(editor);
       }
       editorOnChange.current = editor.onDidChangeModelContent(() => {
         if (project.project?.accounts) {
@@ -174,6 +173,7 @@ const CadenceEditor = (props: CadenceEditorProps) => {
     editor.restoreViewState(state.viewState);
     editor.focus();
     editor.layout();
+    addCustomActions(editor);
 
     // Save editor in component state
     setEditor(editor);

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -14,13 +14,20 @@ export const getParams = (url: string): any => {
     }, {});
 };
 
+export const buildHashUrl = (lineNumbers: number[]): string => {
+  const url = window.location.href.split('#')[0];
+  const hash = lineNumbers.map((l) => `L${l}`).join('-');
+  return `${url}#${hash}`;
+};
+
 export const getHashLineNumber = (): number[] => {
   const value = window.location.hash?.substring(1);
   if (!value) return [];
 
-  const lineNumbers = value.toLocaleUpperCase().replace('L', '');
+  const lineNumbers = value.toLocaleUpperCase().replace(/L/g, '');
   if (lineNumbers.includes('-')) {
     const [start, end] = lineNumbers.split('-');
+    if (start === end) return [Number(start)];
     return [Number(start), Number(end)];
   }
   return [Number(lineNumbers)];


### PR DESCRIPTION
References: https://github.com/onflow/flow-playground/issues/129

## Description

User can build a hash url with highlighting one line
![image](https://github.com/onflow/flow-playground/assets/3970376/40c0f7ee-aae7-4656-b825-aee18a9bcd3f)


User can build a hash url with a selection, highlighting multiple lines
![image](https://github.com/onflow/flow-playground/assets/3970376/017785d1-b988-472c-8e5a-947cf48049c3)


______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

