### PR TITLE
use new version of language server, style hint messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hotjar/browser": "^1.0.6",
         "@ibm/plex": "^6.1.1",
         "@mdx-js/react": "^2.1.3",
-        "@onflow/cadence-language-server": "^0.28.0",
+        "@onflow/cadence-language-server": "^0.29.2",
         "@reach/router": "^1.3.4",
         "@sentry/integrations": "^7.44.0",
         "@sentry/react": "^7.44.0",
@@ -4975,9 +4975,9 @@
       }
     },
     "node_modules/@onflow/cadence-language-server": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@onflow/cadence-language-server/-/cadence-language-server-0.28.0.tgz",
-      "integrity": "sha512-e9TqBiGogG7dkzfLIR4uL8JNuVckCl7pi++agNCINTTRqGQtXAcWTHnfNV402bzWpjAO756jupkzpU6kr7Ytcw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@onflow/cadence-language-server/-/cadence-language-server-0.29.2.tgz",
+      "integrity": "sha512-et+h0OljvXD3tizkVXZ5KspkBh3Aq9jxEeoxG7g4Ts3IE4zIGLfCjXXdNOGWZPic+FyKrn6eVEnWFoiFc3YSkA==",
       "dependencies": {
         "vscode-jsonrpc": "^5.0.1"
       }
@@ -22991,9 +22991,9 @@
       }
     },
     "@onflow/cadence-language-server": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@onflow/cadence-language-server/-/cadence-language-server-0.28.0.tgz",
-      "integrity": "sha512-e9TqBiGogG7dkzfLIR4uL8JNuVckCl7pi++agNCINTTRqGQtXAcWTHnfNV402bzWpjAO756jupkzpU6kr7Ytcw==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@onflow/cadence-language-server/-/cadence-language-server-0.29.2.tgz",
+      "integrity": "sha512-et+h0OljvXD3tizkVXZ5KspkBh3Aq9jxEeoxG7g4Ts3IE4zIGLfCjXXdNOGWZPic+FyKrn6eVEnWFoiFc3YSkA==",
       "requires": {
         "vscode-jsonrpc": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@hotjar/browser": "^1.0.6",
     "@ibm/plex": "^6.1.1",
     "@mdx-js/react": "^2.1.3",
-    "@onflow/cadence-language-server": "^0.28.0",
+    "@onflow/cadence-language-server": "^0.29.2",
     "@reach/router": "^1.3.4",
     "@sentry/integrations": "^7.44.0",
     "@sentry/react": "^7.44.0",

--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -31,6 +31,7 @@ export type ContractDeployment = {
   __typename?: 'ContractDeployment';
   id: Scalars['UUID'];
   script: Scalars['String'];
+  arguments: ['String']
   title: Scalars['String'];
   address: Scalars['Address'];
   errors?: Maybe<Array<ProgramError>>;
@@ -194,6 +195,7 @@ export type NewContractDeployment = {
   projectId: Scalars['UUID'];
   script: Scalars['String'];
   address: Scalars['Address'];
+  arguments?: Maybe<Array<Scalars['String']>>;
 };
 
 export type NewContractTemplate = {

--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -1,10 +1,17 @@
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
+/** This file is mostly generated, see package.json for command.
+ * Consolidating React Apollo libs into single Apollo object, 
+ * The generator expectas all hooks and common methods are in an Apollo object.
+ * Doing this will make it easier next time generator is used. 
+ * */
+const Apollo = { ...ApolloReactHooks, ...ApolloReactCommon };
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -29,23 +36,23 @@ export type Account = {
 
 export type ContractDeployment = {
   __typename?: 'ContractDeployment';
-  id: Scalars['UUID'];
-  script: Scalars['String'];
-  arguments: ['String']
-  title: Scalars['String'];
   address: Scalars['Address'];
+  arguments?: Maybe<Array<Scalars['String']>>;
+  blockHeight: Scalars['Int'];
   errors?: Maybe<Array<ProgramError>>;
   events?: Maybe<Array<Event>>;
+  id: Scalars['UUID'];
   logs?: Maybe<Array<Scalars['String']>>;
-  blockHeight?: Maybe<Scalars['Int']>;
+  script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type ContractTemplate = {
   __typename?: 'ContractTemplate';
   id: Scalars['UUID'];
   index: Scalars['Int'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type Event = {
@@ -56,10 +63,10 @@ export type Event = {
 
 export type ExecutionResult = {
   __typename?: 'ExecutionResult';
-  timestamp?: Maybe<Scalars['String']>;
-  tag?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['ExecutionResultValue']>;
   label?: Maybe<Scalars['String']>;
+  tag?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['ExecutionResultValue']>;
 };
 
 export type ExecutionResultInput = {
@@ -69,9 +76,9 @@ export type ExecutionResultInput = {
 
 export type ExecutionResults = {
   __typename?: 'ExecutionResults';
-  TRANSACTION?: Maybe<Array<Maybe<ExecutionResult>>>;
-  SCRIPT?: Maybe<Array<Maybe<ExecutionResult>>>;
   CONTRACT?: Maybe<Array<Maybe<ExecutionResult>>>;
+  SCRIPT?: Maybe<Array<Maybe<ExecutionResult>>>;
+  TRANSACTION?: Maybe<Array<Maybe<ExecutionResult>>>;
 };
 
 export type Mutation = {
@@ -88,6 +95,7 @@ export type Mutation = {
   deleteProject: Scalars['UUID'];
   deleteScriptTemplate: Scalars['UUID'];
   deleteTransactionTemplate: Scalars['UUID'];
+  resetProjectState: Scalars['UUID'];
   setActiveProjectId?: Maybe<Scalars['Boolean']>;
   updateCachedExecutionResults?: Maybe<Scalars['Boolean']>;
   updateContractTemplate: ContractTemplate;
@@ -160,15 +168,20 @@ export type MutationDeleteTransactionTemplateArgs = {
 };
 
 
+export type MutationResetProjectStateArgs = {
+  projectId: Scalars['UUID'];
+};
+
+
 export type MutationSetActiveProjectIdArgs = {
   id?: Maybe<Scalars['Int']>;
 };
 
 
 export type MutationUpdateCachedExecutionResultsArgs = {
-  resultType: ResultType;
-  rawResult: Scalars['RawExecutionResult'];
   label?: Maybe<Scalars['String']>;
+  rawResult: Scalars['RawExecutionResult'];
+  resultType: ResultType;
 };
 
 
@@ -192,79 +205,79 @@ export type MutationUpdateTransactionTemplateArgs = {
 };
 
 export type NewContractDeployment = {
-  projectId: Scalars['UUID'];
-  script: Scalars['String'];
   address: Scalars['Address'];
   arguments?: Maybe<Array<Scalars['String']>>;
+  projectId: Scalars['UUID'];
+  script: Scalars['String'];
 };
 
 export type NewContractTemplate = {
   projectId: Scalars['UUID'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewFile = {
   projectId: Scalars['UUID'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewProject = {
-  parentId?: Maybe<Scalars['UUID']>;
-  title: Scalars['String'];
-  description: Scalars['String'];
-  readme: Scalars['String'];
-  seed: Scalars['Int'];
-  numberOfAccounts: Scalars['Int'];
-  transactionTemplates?: Maybe<Array<NewProjectTransactionTemplate>>;
-  scriptTemplates?: Maybe<Array<NewProjectScriptTemplate>>;
   contractTemplates?: Maybe<Array<NewProjectContractTemplate>>;
+  description: Scalars['String'];
+  numberOfAccounts: Scalars['Int'];
+  parentId?: Maybe<Scalars['UUID']>;
+  readme: Scalars['String'];
+  scriptTemplates?: Maybe<Array<NewProjectScriptTemplate>>;
+  seed: Scalars['Int'];
+  title: Scalars['String'];
+  transactionTemplates?: Maybe<Array<NewProjectTransactionTemplate>>;
 };
 
 export type NewProjectContractTemplate = {
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewProjectFile = {
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewProjectScriptTemplate = {
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewProjectTransactionTemplate = {
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewScriptExecution = {
+  arguments?: Maybe<Array<Scalars['String']>>;
   projectId: Scalars['UUID'];
   script: Scalars['String'];
-  arguments?: Maybe<Array<Scalars['String']>>;
 };
 
 export type NewScriptTemplate = {
   projectId: Scalars['UUID'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type NewTransactionExecution = {
+  arguments?: Maybe<Array<Scalars['String']>>;
   projectId: Scalars['UUID'];
   script: Scalars['String'];
   signers?: Maybe<Array<Scalars['Address']>>;
-  arguments?: Maybe<Array<Scalars['String']>>;
 };
 
 export type NewTransactionTemplate = {
   projectId: Scalars['UUID'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type PlaygroundInfo = {
@@ -276,39 +289,39 @@ export type PlaygroundInfo = {
 
 export type ProgramError = {
   __typename?: 'ProgramError';
+  endPosition?: Maybe<ProgramPosition>;
   message: Scalars['String'];
   startPosition?: Maybe<ProgramPosition>;
-  endPosition?: Maybe<ProgramPosition>;
 };
 
 export type ProgramPosition = {
   __typename?: 'ProgramPosition';
-  offset: Scalars['Int'];
-  line: Scalars['Int'];
   column: Scalars['Int'];
+  line: Scalars['Int'];
+  offset: Scalars['Int'];
 };
 
 export type Project = {
   __typename?: 'Project';
-  id: Scalars['UUID'];
-  publicId: Scalars['UUID'];
-  parentId?: Maybe<Scalars['UUID']>;
-  title?: Maybe<Scalars['String']>;
+  accounts?: Maybe<Array<Account>>;
+  contractDeployments?: Maybe<Array<ContractDeployment>>;
+  contractTemplates?: Maybe<Array<ContractTemplate>>;
   description?: Maybe<Scalars['String']>;
-  readme?: Maybe<Scalars['String']>;
-  seed: Scalars['Int'];
-  version: Scalars['Version'];
-  persist?: Maybe<Scalars['Boolean']>;
-  updatedAt: Scalars['String'];
+  id: Scalars['UUID'];
   mutable?: Maybe<Scalars['Boolean']>;
   numberOfAccounts: Scalars['Int'];
-  accounts?: Maybe<Array<Account>>;
-  transactionTemplates?: Maybe<Array<TransactionTemplate>>;
-  transactionExecutions?: Maybe<Array<TransactionExecution>>;
-  scriptTemplates?: Maybe<Array<ScriptTemplate>>;
+  parentId?: Maybe<Scalars['UUID']>;
+  persist?: Maybe<Scalars['Boolean']>;
+  publicId: Scalars['UUID'];
+  readme?: Maybe<Scalars['String']>;
   scriptExecutions?: Maybe<Array<ScriptExecution>>;
-  contractTemplates?: Maybe<Array<ContractTemplate>>;
-  contractDeployments?: Maybe<Array<ContractDeployment>>;
+  scriptTemplates?: Maybe<Array<ScriptTemplate>>;
+  seed: Scalars['Int'];
+  title?: Maybe<Scalars['String']>;
+  transactionExecutions?: Maybe<Array<TransactionExecution>>;
+  transactionTemplates?: Maybe<Array<TransactionTemplate>>;
+  updatedAt: Scalars['String'];
+  version: Scalars['Version'];
 };
 
 export type ProjectList = {
@@ -323,6 +336,7 @@ export type Query = {
   activeProjectId?: Maybe<Scalars['Int']>;
   cachedExecutionResults: Array<Maybe<ExecutionResults>>;
   contractTemplate: ContractTemplate;
+  flowJson: Scalars['String'];
   localProject?: Maybe<Project>;
   playgroundInfo: PlaygroundInfo;
   project: Project;
@@ -346,6 +360,11 @@ export type QueryContractTemplateArgs = {
 };
 
 
+export type QueryFlowJsonArgs = {
+  projectId: Scalars['UUID'];
+};
+
+
 export type QueryProjectArgs = {
   id: Scalars['UUID'];
 };
@@ -364,38 +383,38 @@ export type QueryTransactionTemplateArgs = {
 
 
 export enum ResultType {
-  Transaction = 'TRANSACTION',
+  Contract = 'CONTRACT',
   Script = 'SCRIPT',
-  Contract = 'CONTRACT'
+  Transaction = 'TRANSACTION'
 }
 
 export type ScriptExecution = {
   __typename?: 'ScriptExecution';
-  id: Scalars['UUID'];
-  script: Scalars['String'];
   arguments?: Maybe<Array<Scalars['String']>>;
   errors?: Maybe<Array<ProgramError>>;
-  value: Scalars['String'];
+  id: Scalars['UUID'];
   logs: Array<Scalars['String']>;
+  script: Scalars['String'];
+  value: Scalars['String'];
 };
 
 export type ScriptTemplate = {
   __typename?: 'ScriptTemplate';
   id: Scalars['UUID'];
   index: Scalars['Int'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 export type TransactionExecution = {
   __typename?: 'TransactionExecution';
-  id: Scalars['UUID'];
-  script: Scalars['String'];
   arguments?: Maybe<Array<Scalars['String']>>;
-  signers: Array<Scalars['Address']>;
   errors?: Maybe<Array<ProgramError>>;
   events: Array<Maybe<Event>>;
+  id: Scalars['UUID'];
   logs: Array<Scalars['String']>;
+  script: Scalars['String'];
+  signers: Array<Scalars['Address']>;
 };
 
 /**
@@ -411,49 +430,49 @@ export type TransactionTemplate = {
   __typename?: 'TransactionTemplate';
   id: Scalars['UUID'];
   index: Scalars['Int'];
-  title: Scalars['String'];
   script: Scalars['String'];
+  title: Scalars['String'];
 };
 
 
 export type UpdateContractTemplate = {
   id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  projectId: Scalars['UUID'];
   index?: Maybe<Scalars['Int']>;
+  projectId: Scalars['UUID'];
   script?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
 };
 
 export type UpdateFile = {
   id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  projectId: Scalars['UUID'];
   index?: Maybe<Scalars['Int']>;
+  projectId: Scalars['UUID'];
   script?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
 };
 
 export type UpdateProject = {
-  id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
-  readme?: Maybe<Scalars['String']>;
+  id: Scalars['UUID'];
   persist?: Maybe<Scalars['Boolean']>;
+  readme?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
 };
 
 export type UpdateScriptTemplate = {
   id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  projectId: Scalars['UUID'];
   index?: Maybe<Scalars['Int']>;
+  projectId: Scalars['UUID'];
   script?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
 };
 
 export type UpdateTransactionTemplate = {
   id: Scalars['UUID'];
-  title?: Maybe<Scalars['String']>;
-  projectId: Scalars['UUID'];
   index?: Maybe<Scalars['Int']>;
+  projectId: Scalars['UUID'];
   script?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
 };
 
 
@@ -563,6 +582,7 @@ export type CreateContractDeploymentMutationVariables = Exact<{
   projectId: Scalars['UUID'];
   script: Scalars['String'];
   signer: Scalars['Address'];
+  arguments?: Maybe<Array<Scalars['String']> | Scalars['String']>;
 }>;
 
 
@@ -738,6 +758,16 @@ export type DeleteProjectMutation = (
   & Pick<Mutation, 'deleteProject'>
 );
 
+export type ResetProjectMutationVariables = Exact<{
+  projectId: Scalars['UUID'];
+}>;
+
+
+export type ResetProjectMutation = (
+  { __typename?: 'Mutation' }
+  & Pick<Mutation, 'resetProjectState'>
+);
+
 export type SetExecutionResultsMutationVariables = Exact<{
   resultType: ResultType;
   rawResult: Scalars['RawExecutionResult'];
@@ -772,13 +802,16 @@ export type GetProjectsQuery = (
       & Pick<Project, 'id' | 'updatedAt' | 'title'>
       & { contractTemplates?: Maybe<Array<(
         { __typename?: 'ContractTemplate' }
-        & Pick<ContractTemplate, 'id' | 'script' | 'title'>
+        & Pick<ContractTemplate, 'id' | 'script' | 'title' | 'index'>
       )>>, transactionTemplates?: Maybe<Array<(
         { __typename?: 'TransactionTemplate' }
-        & Pick<TransactionTemplate, 'id' | 'script' | 'title'>
+        & Pick<TransactionTemplate, 'id' | 'script' | 'title' | 'index'>
       )>>, scriptTemplates?: Maybe<Array<(
         { __typename?: 'ScriptTemplate' }
-        & Pick<ScriptTemplate, 'id' | 'script' | 'title'>
+        & Pick<ScriptTemplate, 'id' | 'script' | 'title' | 'index'>
+      )>>, contractDeployments?: Maybe<Array<(
+        { __typename?: 'ContractDeployment' }
+        & Pick<ContractDeployment, 'id' | 'script' | 'title' | 'address' | 'blockHeight'>
       )>> }
     )>> }
   ) }
@@ -799,13 +832,19 @@ export type GetProjectQuery = (
       & Pick<Account, 'address' | 'deployedContracts' | 'state'>
     )>>, contractTemplates?: Maybe<Array<(
       { __typename?: 'ContractTemplate' }
-      & Pick<ContractTemplate, 'id' | 'script' | 'title'>
+      & Pick<ContractTemplate, 'id' | 'script' | 'title' | 'index'>
     )>>, transactionTemplates?: Maybe<Array<(
       { __typename?: 'TransactionTemplate' }
-      & Pick<TransactionTemplate, 'id' | 'script' | 'title'>
+      & Pick<TransactionTemplate, 'id' | 'script' | 'title' | 'index'>
     )>>, scriptTemplates?: Maybe<Array<(
       { __typename?: 'ScriptTemplate' }
-      & Pick<ScriptTemplate, 'id' | 'script' | 'title'>
+      & Pick<ScriptTemplate, 'id' | 'script' | 'title' | 'index'>
+    )>>, contractDeployments?: Maybe<Array<(
+      { __typename?: 'ContractDeployment' }
+      & Pick<ContractDeployment, 'id' | 'script' | 'title' | 'address' | 'blockHeight'>
+    )>>, transactionExecutions?: Maybe<Array<(
+      { __typename?: 'TransactionExecution' }
+      & Pick<TransactionExecution, 'id' | 'script' | 'arguments' | 'signers' | 'logs'>
     )>> }
   ) }
 );
@@ -823,13 +862,13 @@ export type GetLocalProjectQuery = (
       & Pick<Account, 'address' | 'deployedContracts' | 'state'>
     )>>, contractTemplates?: Maybe<Array<(
       { __typename?: 'ContractTemplate' }
-      & Pick<ContractTemplate, 'id' | 'script' | 'title'>
+      & Pick<ContractTemplate, 'id' | 'script' | 'title' | 'index'>
     )>>, transactionTemplates?: Maybe<Array<(
       { __typename?: 'TransactionTemplate' }
-      & Pick<TransactionTemplate, 'id' | 'script' | 'title'>
+      & Pick<TransactionTemplate, 'id' | 'script' | 'title' | 'index'>
     )>>, scriptTemplates?: Maybe<Array<(
       { __typename?: 'ScriptTemplate' }
-      & Pick<ScriptTemplate, 'id' | 'script' | 'title'>
+      & Pick<ScriptTemplate, 'id' | 'script' | 'title' | 'index'>
     )>> }
   )> }
 );
@@ -865,6 +904,17 @@ export type GetCachedExecutionResultsQuery = (
       & ExecutionResultDetailsFragment
     )>>> }
   )>> }
+);
+
+export type GetPlaygroundInfoQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetPlaygroundInfoQuery = (
+  { __typename?: 'Query' }
+  & { playgroundInfo: (
+    { __typename?: 'PlaygroundInfo' }
+    & Pick<PlaygroundInfo, 'apiVersion' | 'cadenceVersion' | 'emulatorVersion'>
+  ) }
 );
 
 export type TxResultsFragment = (
@@ -1005,7 +1055,7 @@ export const CreateProjectDocument = gql`
   }
 }
     `;
-export type CreateProjectMutationFn = ApolloReactCommon.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
 
 /**
  * __useCreateProjectMutation__
@@ -1032,12 +1082,13 @@ export type CreateProjectMutationFn = ApolloReactCommon.MutationFunction<CreateP
  *   },
  * });
  */
-export function useCreateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, baseOptions);
+export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
       }
 export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = ApolloReactCommon.MutationResult<CreateProjectMutation>;
-export type CreateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
+export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
 export const UpdateProjectDocument = gql`
     mutation UpdateProject($projectId: UUID!, $title: String!, $description: String!, $readme: String!) {
   updateProject(
@@ -1051,7 +1102,7 @@ export const UpdateProjectDocument = gql`
   }
 }
     `;
-export type UpdateProjectMutationFn = ApolloReactCommon.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
 
 /**
  * __useUpdateProjectMutation__
@@ -1073,18 +1124,19 @@ export type UpdateProjectMutationFn = ApolloReactCommon.MutationFunction<UpdateP
  *   },
  * });
  */
-export function useUpdateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, baseOptions);
+export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, options);
       }
 export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
-export type UpdateProjectMutationResult = ApolloReactCommon.MutationResult<UpdateProjectMutation>;
-export type UpdateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
+export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
 export const SetActiveProjectDocument = gql`
     mutation SetActiveProject($id: Int!) {
   setActiveProjectId(id: $id) @client
 }
     `;
-export type SetActiveProjectMutationFn = ApolloReactCommon.MutationFunction<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
+export type SetActiveProjectMutationFn = Apollo.MutationFunction<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
 
 /**
  * __useSetActiveProjectMutation__
@@ -1103,12 +1155,13 @@ export type SetActiveProjectMutationFn = ApolloReactCommon.MutationFunction<SetA
  *   },
  * });
  */
-export function useSetActiveProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>) {
-        return ApolloReactHooks.useMutation<SetActiveProjectMutation, SetActiveProjectMutationVariables>(SetActiveProjectDocument, baseOptions);
+export function useSetActiveProjectMutation(baseOptions?: Apollo.MutationHookOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetActiveProjectMutation, SetActiveProjectMutationVariables>(SetActiveProjectDocument, options);
       }
 export type SetActiveProjectMutationHookResult = ReturnType<typeof useSetActiveProjectMutation>;
-export type SetActiveProjectMutationResult = ApolloReactCommon.MutationResult<SetActiveProjectMutation>;
-export type SetActiveProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
+export type SetActiveProjectMutationResult = Apollo.MutationResult<SetActiveProjectMutation>;
+export type SetActiveProjectMutationOptions = Apollo.BaseMutationOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
 export const CreateContractTemplateDocument = gql`
     mutation CreateContractTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createContractTemplate(
@@ -1120,7 +1173,7 @@ export const CreateContractTemplateDocument = gql`
   }
 }
     `;
-export type CreateContractTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
+export type CreateContractTemplateMutationFn = Apollo.MutationFunction<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
 
 /**
  * __useCreateContractTemplateMutation__
@@ -1141,12 +1194,13 @@ export type CreateContractTemplateMutationFn = ApolloReactCommon.MutationFunctio
  *   },
  * });
  */
-export function useCreateContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>(CreateContractTemplateDocument, baseOptions);
+export function useCreateContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>(CreateContractTemplateDocument, options);
       }
 export type CreateContractTemplateMutationHookResult = ReturnType<typeof useCreateContractTemplateMutation>;
-export type CreateContractTemplateMutationResult = ApolloReactCommon.MutationResult<CreateContractTemplateMutation>;
-export type CreateContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
+export type CreateContractTemplateMutationResult = Apollo.MutationResult<CreateContractTemplateMutation>;
+export type CreateContractTemplateMutationOptions = Apollo.BaseMutationOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
 export const UpdateContractTemplateDocument = gql`
     mutation UpdateContractTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateContractTemplate(
@@ -1159,7 +1213,7 @@ export const UpdateContractTemplateDocument = gql`
   }
 }
     `;
-export type UpdateContractTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
+export type UpdateContractTemplateMutationFn = Apollo.MutationFunction<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
 
 /**
  * __useUpdateContractTemplateMutation__
@@ -1181,18 +1235,19 @@ export type UpdateContractTemplateMutationFn = ApolloReactCommon.MutationFunctio
  *   },
  * });
  */
-export function useUpdateContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>(UpdateContractTemplateDocument, baseOptions);
+export function useUpdateContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>(UpdateContractTemplateDocument, options);
       }
 export type UpdateContractTemplateMutationHookResult = ReturnType<typeof useUpdateContractTemplateMutation>;
-export type UpdateContractTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateContractTemplateMutation>;
-export type UpdateContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
+export type UpdateContractTemplateMutationResult = Apollo.MutationResult<UpdateContractTemplateMutation>;
+export type UpdateContractTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
 export const DeleteContractTemplateDocument = gql`
     mutation DeleteContractTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteContractTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteContractTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
+export type DeleteContractTemplateMutationFn = Apollo.MutationFunction<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
 
 /**
  * __useDeleteContractTemplateMutation__
@@ -1212,16 +1267,17 @@ export type DeleteContractTemplateMutationFn = ApolloReactCommon.MutationFunctio
  *   },
  * });
  */
-export function useDeleteContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>(DeleteContractTemplateDocument, baseOptions);
+export function useDeleteContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>(DeleteContractTemplateDocument, options);
       }
 export type DeleteContractTemplateMutationHookResult = ReturnType<typeof useDeleteContractTemplateMutation>;
-export type DeleteContractTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteContractTemplateMutation>;
-export type DeleteContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
+export type DeleteContractTemplateMutationResult = Apollo.MutationResult<DeleteContractTemplateMutation>;
+export type DeleteContractTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
 export const CreateContractDeploymentDocument = gql`
-    mutation CreateContractDeployment($projectId: UUID!, $script: String!, $signer: Address!) {
+    mutation CreateContractDeployment($projectId: UUID!, $script: String!, $signer: Address!, $arguments: [String!]) {
   createContractDeployment(
-    input: {projectId: $projectId, script: $script, address: $signer}
+    input: {projectId: $projectId, script: $script, address: $signer, arguments: $arguments}
   ) {
     id
     script
@@ -1246,7 +1302,7 @@ export const CreateContractDeploymentDocument = gql`
   }
 }
     `;
-export type CreateContractDeploymentMutationFn = ApolloReactCommon.MutationFunction<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
+export type CreateContractDeploymentMutationFn = Apollo.MutationFunction<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
 
 /**
  * __useCreateContractDeploymentMutation__
@@ -1264,15 +1320,17 @@ export type CreateContractDeploymentMutationFn = ApolloReactCommon.MutationFunct
  *      projectId: // value for 'projectId'
  *      script: // value for 'script'
  *      signer: // value for 'signer'
+ *      arguments: // value for 'arguments'
  *   },
  * });
  */
-export function useCreateContractDeploymentMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>(CreateContractDeploymentDocument, baseOptions);
+export function useCreateContractDeploymentMutation(baseOptions?: Apollo.MutationHookOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>(CreateContractDeploymentDocument, options);
       }
 export type CreateContractDeploymentMutationHookResult = ReturnType<typeof useCreateContractDeploymentMutation>;
-export type CreateContractDeploymentMutationResult = ApolloReactCommon.MutationResult<CreateContractDeploymentMutation>;
-export type CreateContractDeploymentMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
+export type CreateContractDeploymentMutationResult = Apollo.MutationResult<CreateContractDeploymentMutation>;
+export type CreateContractDeploymentMutationOptions = Apollo.BaseMutationOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
 export const UpdateTransactionTemplateDocument = gql`
     mutation UpdateTransactionTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateTransactionTemplate(
@@ -1285,7 +1343,7 @@ export const UpdateTransactionTemplateDocument = gql`
   }
 }
     `;
-export type UpdateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
+export type UpdateTransactionTemplateMutationFn = Apollo.MutationFunction<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
 
 /**
  * __useUpdateTransactionTemplateMutation__
@@ -1307,12 +1365,13 @@ export type UpdateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunc
  *   },
  * });
  */
-export function useUpdateTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>(UpdateTransactionTemplateDocument, baseOptions);
+export function useUpdateTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>(UpdateTransactionTemplateDocument, options);
       }
 export type UpdateTransactionTemplateMutationHookResult = ReturnType<typeof useUpdateTransactionTemplateMutation>;
-export type UpdateTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateTransactionTemplateMutation>;
-export type UpdateTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
+export type UpdateTransactionTemplateMutationResult = Apollo.MutationResult<UpdateTransactionTemplateMutation>;
+export type UpdateTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
 export const CreateTransactionTemplateDocument = gql`
     mutation CreateTransactionTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createTransactionTemplate(
@@ -1324,7 +1383,7 @@ export const CreateTransactionTemplateDocument = gql`
   }
 }
     `;
-export type CreateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
+export type CreateTransactionTemplateMutationFn = Apollo.MutationFunction<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
 
 /**
  * __useCreateTransactionTemplateMutation__
@@ -1345,18 +1404,19 @@ export type CreateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunc
  *   },
  * });
  */
-export function useCreateTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>(CreateTransactionTemplateDocument, baseOptions);
+export function useCreateTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>(CreateTransactionTemplateDocument, options);
       }
 export type CreateTransactionTemplateMutationHookResult = ReturnType<typeof useCreateTransactionTemplateMutation>;
-export type CreateTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<CreateTransactionTemplateMutation>;
-export type CreateTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
+export type CreateTransactionTemplateMutationResult = Apollo.MutationResult<CreateTransactionTemplateMutation>;
+export type CreateTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
 export const DeleteTransactionTemplateDocument = gql`
     mutation DeleteTransactionTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteTransactionTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
+export type DeleteTransactionTemplateMutationFn = Apollo.MutationFunction<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
 
 /**
  * __useDeleteTransactionTemplateMutation__
@@ -1376,12 +1436,13 @@ export type DeleteTransactionTemplateMutationFn = ApolloReactCommon.MutationFunc
  *   },
  * });
  */
-export function useDeleteTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>(DeleteTransactionTemplateDocument, baseOptions);
+export function useDeleteTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>(DeleteTransactionTemplateDocument, options);
       }
 export type DeleteTransactionTemplateMutationHookResult = ReturnType<typeof useDeleteTransactionTemplateMutation>;
-export type DeleteTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteTransactionTemplateMutation>;
-export type DeleteTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
+export type DeleteTransactionTemplateMutationResult = Apollo.MutationResult<DeleteTransactionTemplateMutation>;
+export type DeleteTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
 export const CreateTransactionExecutionDocument = gql`
     mutation CreateTransactionExecution($projectId: UUID!, $script: String!, $signers: [Address!], $arguments: [String!]) {
   createTransactionExecution(
@@ -1410,7 +1471,7 @@ export const CreateTransactionExecutionDocument = gql`
   }
 }
     `;
-export type CreateTransactionExecutionMutationFn = ApolloReactCommon.MutationFunction<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
+export type CreateTransactionExecutionMutationFn = Apollo.MutationFunction<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
 
 /**
  * __useCreateTransactionExecutionMutation__
@@ -1432,12 +1493,13 @@ export type CreateTransactionExecutionMutationFn = ApolloReactCommon.MutationFun
  *   },
  * });
  */
-export function useCreateTransactionExecutionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>(CreateTransactionExecutionDocument, baseOptions);
+export function useCreateTransactionExecutionMutation(baseOptions?: Apollo.MutationHookOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>(CreateTransactionExecutionDocument, options);
       }
 export type CreateTransactionExecutionMutationHookResult = ReturnType<typeof useCreateTransactionExecutionMutation>;
-export type CreateTransactionExecutionMutationResult = ApolloReactCommon.MutationResult<CreateTransactionExecutionMutation>;
-export type CreateTransactionExecutionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
+export type CreateTransactionExecutionMutationResult = Apollo.MutationResult<CreateTransactionExecutionMutation>;
+export type CreateTransactionExecutionMutationOptions = Apollo.BaseMutationOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
 export const UpdateScripTemplateDocument = gql`
     mutation UpdateScripTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateScriptTemplate(
@@ -1450,7 +1512,7 @@ export const UpdateScripTemplateDocument = gql`
   }
 }
     `;
-export type UpdateScripTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
+export type UpdateScripTemplateMutationFn = Apollo.MutationFunction<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
 
 /**
  * __useUpdateScripTemplateMutation__
@@ -1472,12 +1534,13 @@ export type UpdateScripTemplateMutationFn = ApolloReactCommon.MutationFunction<U
  *   },
  * });
  */
-export function useUpdateScripTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>(UpdateScripTemplateDocument, baseOptions);
+export function useUpdateScripTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>(UpdateScripTemplateDocument, options);
       }
 export type UpdateScripTemplateMutationHookResult = ReturnType<typeof useUpdateScripTemplateMutation>;
-export type UpdateScripTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateScripTemplateMutation>;
-export type UpdateScripTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
+export type UpdateScripTemplateMutationResult = Apollo.MutationResult<UpdateScripTemplateMutation>;
+export type UpdateScripTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
 export const CreateScriptTemplateDocument = gql`
     mutation CreateScriptTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createScriptTemplate(
@@ -1489,7 +1552,7 @@ export const CreateScriptTemplateDocument = gql`
   }
 }
     `;
-export type CreateScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
+export type CreateScriptTemplateMutationFn = Apollo.MutationFunction<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
 
 /**
  * __useCreateScriptTemplateMutation__
@@ -1510,18 +1573,19 @@ export type CreateScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<
  *   },
  * });
  */
-export function useCreateScriptTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>(CreateScriptTemplateDocument, baseOptions);
+export function useCreateScriptTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>(CreateScriptTemplateDocument, options);
       }
 export type CreateScriptTemplateMutationHookResult = ReturnType<typeof useCreateScriptTemplateMutation>;
-export type CreateScriptTemplateMutationResult = ApolloReactCommon.MutationResult<CreateScriptTemplateMutation>;
-export type CreateScriptTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
+export type CreateScriptTemplateMutationResult = Apollo.MutationResult<CreateScriptTemplateMutation>;
+export type CreateScriptTemplateMutationOptions = Apollo.BaseMutationOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
 export const DeleteScriptTemplateDocument = gql`
     mutation DeleteScriptTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteScriptTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
+export type DeleteScriptTemplateMutationFn = Apollo.MutationFunction<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
 
 /**
  * __useDeleteScriptTemplateMutation__
@@ -1541,12 +1605,13 @@ export type DeleteScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<
  *   },
  * });
  */
-export function useDeleteScriptTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>) {
-        return ApolloReactHooks.useMutation<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>(DeleteScriptTemplateDocument, baseOptions);
+export function useDeleteScriptTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>(DeleteScriptTemplateDocument, options);
       }
 export type DeleteScriptTemplateMutationHookResult = ReturnType<typeof useDeleteScriptTemplateMutation>;
-export type DeleteScriptTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteScriptTemplateMutation>;
-export type DeleteScriptTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
+export type DeleteScriptTemplateMutationResult = Apollo.MutationResult<DeleteScriptTemplateMutation>;
+export type DeleteScriptTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
 export const CreateScriptExecutionDocument = gql`
     mutation CreateScriptExecution($projectId: UUID!, $script: String!, $arguments: [String!]) {
   createScriptExecution(
@@ -1572,7 +1637,7 @@ export const CreateScriptExecutionDocument = gql`
   }
 }
     `;
-export type CreateScriptExecutionMutationFn = ApolloReactCommon.MutationFunction<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
+export type CreateScriptExecutionMutationFn = Apollo.MutationFunction<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
 
 /**
  * __useCreateScriptExecutionMutation__
@@ -1593,18 +1658,19 @@ export type CreateScriptExecutionMutationFn = ApolloReactCommon.MutationFunction
  *   },
  * });
  */
-export function useCreateScriptExecutionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>(CreateScriptExecutionDocument, baseOptions);
+export function useCreateScriptExecutionMutation(baseOptions?: Apollo.MutationHookOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>(CreateScriptExecutionDocument, options);
       }
 export type CreateScriptExecutionMutationHookResult = ReturnType<typeof useCreateScriptExecutionMutation>;
-export type CreateScriptExecutionMutationResult = ApolloReactCommon.MutationResult<CreateScriptExecutionMutation>;
-export type CreateScriptExecutionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
+export type CreateScriptExecutionMutationResult = Apollo.MutationResult<CreateScriptExecutionMutation>;
+export type CreateScriptExecutionMutationOptions = Apollo.BaseMutationOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
 export const DeleteProjectDocument = gql`
     mutation DeleteProject($projectId: UUID!) {
   deleteProject(projectId: $projectId)
 }
     `;
-export type DeleteProjectMutationFn = ApolloReactCommon.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
 
 /**
  * __useDeleteProjectMutation__
@@ -1623,12 +1689,44 @@ export type DeleteProjectMutationFn = ApolloReactCommon.MutationFunction<DeleteP
  *   },
  * });
  */
-export function useDeleteProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
-        return ApolloReactHooks.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
+export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, options);
       }
 export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
-export type DeleteProjectMutationResult = ApolloReactCommon.MutationResult<DeleteProjectMutation>;
-export type DeleteProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type DeleteProjectMutationResult = Apollo.MutationResult<DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export const ResetProjectDocument = gql`
+    mutation ResetProject($projectId: UUID!) {
+  resetProjectState(projectId: $projectId)
+}
+    `;
+export type ResetProjectMutationFn = Apollo.MutationFunction<ResetProjectMutation, ResetProjectMutationVariables>;
+
+/**
+ * __useResetProjectMutation__
+ *
+ * To run a mutation, you first call `useResetProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useResetProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [resetProjectMutation, { data, loading, error }] = useResetProjectMutation({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useResetProjectMutation(baseOptions?: Apollo.MutationHookOptions<ResetProjectMutation, ResetProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ResetProjectMutation, ResetProjectMutationVariables>(ResetProjectDocument, options);
+      }
+export type ResetProjectMutationHookResult = ReturnType<typeof useResetProjectMutation>;
+export type ResetProjectMutationResult = Apollo.MutationResult<ResetProjectMutation>;
+export type ResetProjectMutationOptions = Apollo.BaseMutationOptions<ResetProjectMutation, ResetProjectMutationVariables>;
 export const SetExecutionResultsDocument = gql`
     mutation SetExecutionResults($resultType: ResultType!, $rawResult: RawExecutionResult!, $label: String) {
   updateCachedExecutionResults(
@@ -1638,7 +1736,7 @@ export const SetExecutionResultsDocument = gql`
   ) @client
 }
     `;
-export type SetExecutionResultsMutationFn = ApolloReactCommon.MutationFunction<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
+export type SetExecutionResultsMutationFn = Apollo.MutationFunction<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
 
 /**
  * __useSetExecutionResultsMutation__
@@ -1659,18 +1757,19 @@ export type SetExecutionResultsMutationFn = ApolloReactCommon.MutationFunction<S
  *   },
  * });
  */
-export function useSetExecutionResultsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>) {
-        return ApolloReactHooks.useMutation<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>(SetExecutionResultsDocument, baseOptions);
+export function useSetExecutionResultsMutation(baseOptions?: Apollo.MutationHookOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>(SetExecutionResultsDocument, options);
       }
 export type SetExecutionResultsMutationHookResult = ReturnType<typeof useSetExecutionResultsMutation>;
-export type SetExecutionResultsMutationResult = ApolloReactCommon.MutationResult<SetExecutionResultsMutation>;
-export type SetExecutionResultsMutationOptions = ApolloReactCommon.BaseMutationOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
+export type SetExecutionResultsMutationResult = Apollo.MutationResult<SetExecutionResultsMutation>;
+export type SetExecutionResultsMutationOptions = Apollo.BaseMutationOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
 export const ClearExecutionResultsDocument = gql`
     mutation ClearExecutionResults($resultType: ResultType!) {
   clearCachedExecutionResults(resultType: $resultType) @client
 }
     `;
-export type ClearExecutionResultsMutationFn = ApolloReactCommon.MutationFunction<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
+export type ClearExecutionResultsMutationFn = Apollo.MutationFunction<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
 
 /**
  * __useClearExecutionResultsMutation__
@@ -1689,12 +1788,13 @@ export type ClearExecutionResultsMutationFn = ApolloReactCommon.MutationFunction
  *   },
  * });
  */
-export function useClearExecutionResultsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>) {
-        return ApolloReactHooks.useMutation<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>(ClearExecutionResultsDocument, baseOptions);
+export function useClearExecutionResultsMutation(baseOptions?: Apollo.MutationHookOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>(ClearExecutionResultsDocument, options);
       }
 export type ClearExecutionResultsMutationHookResult = ReturnType<typeof useClearExecutionResultsMutation>;
-export type ClearExecutionResultsMutationResult = ApolloReactCommon.MutationResult<ClearExecutionResultsMutation>;
-export type ClearExecutionResultsMutationOptions = ApolloReactCommon.BaseMutationOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
+export type ClearExecutionResultsMutationResult = Apollo.MutationResult<ClearExecutionResultsMutation>;
+export type ClearExecutionResultsMutationOptions = Apollo.BaseMutationOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
 export const GetProjectsDocument = gql`
     query GetProjects {
   projectList {
@@ -1706,16 +1806,26 @@ export const GetProjectsDocument = gql`
         id
         script
         title
+        index
       }
       transactionTemplates {
         id
         script
         title
+        index
       }
       scriptTemplates {
         id
         script
         title
+        index
+      }
+      contractDeployments {
+        id
+        script
+        title
+        address
+        blockHeight
       }
     }
   }
@@ -1737,15 +1847,17 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
+export function useGetProjectsQuery(baseOptions?: Apollo.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
       }
-export function useGetProjectsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
+export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
         }
 export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
 export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
-export type GetProjectsQueryResult = ApolloReactCommon.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
+export type GetProjectsQueryResult = Apollo.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
 export const GetProjectDocument = gql`
     query GetProject($projectId: UUID!) {
   project(id: $projectId) {
@@ -1767,16 +1879,33 @@ export const GetProjectDocument = gql`
       id
       script
       title
+      index
     }
     transactionTemplates {
       id
       script
       title
+      index
     }
     scriptTemplates {
       id
       script
       title
+      index
+    }
+    contractDeployments {
+      id
+      script
+      title
+      address
+      blockHeight
+    }
+    transactionExecutions {
+      id
+      script
+      arguments
+      signers
+      logs
     }
   }
 }
@@ -1798,15 +1927,17 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
       }
-export function useGetProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
         }
 export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
 export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
-export type GetProjectQueryResult = ApolloReactCommon.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
+export type GetProjectQueryResult = Apollo.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
 export const GetLocalProjectDocument = gql`
     query GetLocalProject {
   project: localProject @client {
@@ -1827,16 +1958,19 @@ export const GetLocalProjectDocument = gql`
       id
       script
       title
+      index
     }
     transactionTemplates {
       id
       script
       title
+      index
     }
     scriptTemplates {
       id
       script
       title
+      index
     }
   }
 }
@@ -1857,15 +1991,17 @@ export const GetLocalProjectDocument = gql`
  *   },
  * });
  */
-export function useGetLocalProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, baseOptions);
+export function useGetLocalProjectQuery(baseOptions?: Apollo.QueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
       }
-export function useGetLocalProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, baseOptions);
+export function useGetLocalProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
         }
 export type GetLocalProjectQueryHookResult = ReturnType<typeof useGetLocalProjectQuery>;
 export type GetLocalProjectLazyQueryHookResult = ReturnType<typeof useGetLocalProjectLazyQuery>;
-export type GetLocalProjectQueryResult = ApolloReactCommon.QueryResult<GetLocalProjectQuery, GetLocalProjectQueryVariables>;
+export type GetLocalProjectQueryResult = Apollo.QueryResult<GetLocalProjectQuery, GetLocalProjectQueryVariables>;
 export const GetActiveProjectDocument = gql`
     query GetActiveProject {
   activeProjectId @client
@@ -1888,15 +2024,17 @@ export const GetActiveProjectDocument = gql`
  *   },
  * });
  */
-export function useGetActiveProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, baseOptions);
+export function useGetActiveProjectQuery(baseOptions?: Apollo.QueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
       }
-export function useGetActiveProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, baseOptions);
+export function useGetActiveProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
         }
 export type GetActiveProjectQueryHookResult = ReturnType<typeof useGetActiveProjectQuery>;
 export type GetActiveProjectLazyQueryHookResult = ReturnType<typeof useGetActiveProjectLazyQuery>;
-export type GetActiveProjectQueryResult = ApolloReactCommon.QueryResult<GetActiveProjectQuery, GetActiveProjectQueryVariables>;
+export type GetActiveProjectQueryResult = Apollo.QueryResult<GetActiveProjectQuery, GetActiveProjectQueryVariables>;
 export const GetCachedExecutionResultsDocument = gql`
     query GetCachedExecutionResults {
   cachedExecutionResults @client {
@@ -1928,15 +2066,53 @@ export const GetCachedExecutionResultsDocument = gql`
  *   },
  * });
  */
-export function useGetCachedExecutionResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, baseOptions);
+export function useGetCachedExecutionResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
       }
-export function useGetCachedExecutionResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, baseOptions);
+export function useGetCachedExecutionResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
         }
 export type GetCachedExecutionResultsQueryHookResult = ReturnType<typeof useGetCachedExecutionResultsQuery>;
 export type GetCachedExecutionResultsLazyQueryHookResult = ReturnType<typeof useGetCachedExecutionResultsLazyQuery>;
-export type GetCachedExecutionResultsQueryResult = ApolloReactCommon.QueryResult<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>;
+export type GetCachedExecutionResultsQueryResult = Apollo.QueryResult<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>;
+export const GetPlaygroundInfoDocument = gql`
+    query GetPlaygroundInfo {
+  playgroundInfo {
+    apiVersion
+    cadenceVersion
+    emulatorVersion
+  }
+}
+    `;
+
+/**
+ * __useGetPlaygroundInfoQuery__
+ *
+ * To run a query within a React component, call `useGetPlaygroundInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPlaygroundInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPlaygroundInfoQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetPlaygroundInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
+      }
+export function useGetPlaygroundInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
+        }
+export type GetPlaygroundInfoQueryHookResult = ReturnType<typeof useGetPlaygroundInfoQuery>;
+export type GetPlaygroundInfoLazyQueryHookResult = ReturnType<typeof useGetPlaygroundInfoLazyQuery>;
+export type GetPlaygroundInfoQueryResult = Apollo.QueryResult<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>;
 export const GetExecutionResultsDocument = gql`
     query GetExecutionResults {
   cachedExecutionResults {
@@ -1977,15 +2153,17 @@ export const GetExecutionResultsDocument = gql`
  *   },
  * });
  */
-export function useGetExecutionResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, baseOptions);
+export function useGetExecutionResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
       }
-export function useGetExecutionResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, baseOptions);
+export function useGetExecutionResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
         }
 export type GetExecutionResultsQueryHookResult = ReturnType<typeof useGetExecutionResultsQuery>;
 export type GetExecutionResultsLazyQueryHookResult = ReturnType<typeof useGetExecutionResultsLazyQuery>;
-export type GetExecutionResultsQueryResult = ApolloReactCommon.QueryResult<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>;
+export type GetExecutionResultsQueryResult = Apollo.QueryResult<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>;
 export const GetResultsDocument = gql`
     query GetResults {
   cachedExecutionResults {
@@ -2026,15 +2204,17 @@ export const GetResultsDocument = gql`
  *   },
  * });
  */
-export function useGetResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, baseOptions);
+export function useGetResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
       }
-export function useGetResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, baseOptions);
+export function useGetResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
         }
 export type GetResultsQueryHookResult = ReturnType<typeof useGetResultsQuery>;
 export type GetResultsLazyQueryHookResult = ReturnType<typeof useGetResultsLazyQuery>;
-export type GetResultsQueryResult = ApolloReactCommon.QueryResult<GetResultsQuery, GetResultsQueryVariables>;
+export type GetResultsQueryResult = Apollo.QueryResult<GetResultsQuery, GetResultsQueryVariables>;
 
       export interface IntrospectionResultData {
         __schema: {

--- a/src/api/apollo/generated/graphql.tsx
+++ b/src/api/apollo/generated/graphql.tsx
@@ -1,12 +1,7 @@
 import gql from 'graphql-tag';
 import * as ApolloReactCommon from '@apollo/react-common';
 import * as ApolloReactHooks from '@apollo/react-hooks';
-/** This file is mostly generated, see package.json for command.
- * Consolidating React Apollo libs into single Apollo object, 
- * The generator expectas all hooks and common methods are in an Apollo object.
- * Doing this will make it easier next time generator is used. 
- * */
-const Apollo = { ...ApolloReactHooks, ...ApolloReactCommon };
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -1055,7 +1050,7 @@ export const CreateProjectDocument = gql`
   }
 }
     `;
-export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+export type CreateProjectMutationFn = ApolloReactCommon.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
 
 /**
  * __useCreateProjectMutation__
@@ -1082,13 +1077,13 @@ export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutat
  *   },
  * });
  */
-export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
+export function useCreateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
+        return ApolloReactHooks.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
       }
 export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
+export type CreateProjectMutationResult = ApolloReactCommon.MutationResult<CreateProjectMutation>;
+export type CreateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
 export const UpdateProjectDocument = gql`
     mutation UpdateProject($projectId: UUID!, $title: String!, $description: String!, $readme: String!) {
   updateProject(
@@ -1102,7 +1097,7 @@ export const UpdateProjectDocument = gql`
   }
 }
     `;
-export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateProjectMutationFn = ApolloReactCommon.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
 
 /**
  * __useUpdateProjectMutation__
@@ -1124,19 +1119,19 @@ export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutat
  *   },
  * });
  */
-export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
+export function useUpdateProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, options);
+        return ApolloReactHooks.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, options);
       }
 export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
-export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
-export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export type UpdateProjectMutationResult = ApolloReactCommon.MutationResult<UpdateProjectMutation>;
+export type UpdateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
 export const SetActiveProjectDocument = gql`
     mutation SetActiveProject($id: Int!) {
   setActiveProjectId(id: $id) @client
 }
     `;
-export type SetActiveProjectMutationFn = Apollo.MutationFunction<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
+export type SetActiveProjectMutationFn = ApolloReactCommon.MutationFunction<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
 
 /**
  * __useSetActiveProjectMutation__
@@ -1155,13 +1150,13 @@ export type SetActiveProjectMutationFn = Apollo.MutationFunction<SetActiveProjec
  *   },
  * });
  */
-export function useSetActiveProjectMutation(baseOptions?: Apollo.MutationHookOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>) {
+export function useSetActiveProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SetActiveProjectMutation, SetActiveProjectMutationVariables>(SetActiveProjectDocument, options);
+        return ApolloReactHooks.useMutation<SetActiveProjectMutation, SetActiveProjectMutationVariables>(SetActiveProjectDocument, options);
       }
 export type SetActiveProjectMutationHookResult = ReturnType<typeof useSetActiveProjectMutation>;
-export type SetActiveProjectMutationResult = Apollo.MutationResult<SetActiveProjectMutation>;
-export type SetActiveProjectMutationOptions = Apollo.BaseMutationOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
+export type SetActiveProjectMutationResult = ApolloReactCommon.MutationResult<SetActiveProjectMutation>;
+export type SetActiveProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<SetActiveProjectMutation, SetActiveProjectMutationVariables>;
 export const CreateContractTemplateDocument = gql`
     mutation CreateContractTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createContractTemplate(
@@ -1173,7 +1168,7 @@ export const CreateContractTemplateDocument = gql`
   }
 }
     `;
-export type CreateContractTemplateMutationFn = Apollo.MutationFunction<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
+export type CreateContractTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
 
 /**
  * __useCreateContractTemplateMutation__
@@ -1194,13 +1189,13 @@ export type CreateContractTemplateMutationFn = Apollo.MutationFunction<CreateCon
  *   },
  * });
  */
-export function useCreateContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>) {
+export function useCreateContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>(CreateContractTemplateDocument, options);
+        return ApolloReactHooks.useMutation<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>(CreateContractTemplateDocument, options);
       }
 export type CreateContractTemplateMutationHookResult = ReturnType<typeof useCreateContractTemplateMutation>;
-export type CreateContractTemplateMutationResult = Apollo.MutationResult<CreateContractTemplateMutation>;
-export type CreateContractTemplateMutationOptions = Apollo.BaseMutationOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
+export type CreateContractTemplateMutationResult = ApolloReactCommon.MutationResult<CreateContractTemplateMutation>;
+export type CreateContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateContractTemplateMutation, CreateContractTemplateMutationVariables>;
 export const UpdateContractTemplateDocument = gql`
     mutation UpdateContractTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateContractTemplate(
@@ -1213,7 +1208,7 @@ export const UpdateContractTemplateDocument = gql`
   }
 }
     `;
-export type UpdateContractTemplateMutationFn = Apollo.MutationFunction<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
+export type UpdateContractTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
 
 /**
  * __useUpdateContractTemplateMutation__
@@ -1235,19 +1230,19 @@ export type UpdateContractTemplateMutationFn = Apollo.MutationFunction<UpdateCon
  *   },
  * });
  */
-export function useUpdateContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>) {
+export function useUpdateContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>(UpdateContractTemplateDocument, options);
+        return ApolloReactHooks.useMutation<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>(UpdateContractTemplateDocument, options);
       }
 export type UpdateContractTemplateMutationHookResult = ReturnType<typeof useUpdateContractTemplateMutation>;
-export type UpdateContractTemplateMutationResult = Apollo.MutationResult<UpdateContractTemplateMutation>;
-export type UpdateContractTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
+export type UpdateContractTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateContractTemplateMutation>;
+export type UpdateContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateContractTemplateMutation, UpdateContractTemplateMutationVariables>;
 export const DeleteContractTemplateDocument = gql`
     mutation DeleteContractTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteContractTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteContractTemplateMutationFn = Apollo.MutationFunction<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
+export type DeleteContractTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
 
 /**
  * __useDeleteContractTemplateMutation__
@@ -1267,13 +1262,13 @@ export type DeleteContractTemplateMutationFn = Apollo.MutationFunction<DeleteCon
  *   },
  * });
  */
-export function useDeleteContractTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>) {
+export function useDeleteContractTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>(DeleteContractTemplateDocument, options);
+        return ApolloReactHooks.useMutation<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>(DeleteContractTemplateDocument, options);
       }
 export type DeleteContractTemplateMutationHookResult = ReturnType<typeof useDeleteContractTemplateMutation>;
-export type DeleteContractTemplateMutationResult = Apollo.MutationResult<DeleteContractTemplateMutation>;
-export type DeleteContractTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
+export type DeleteContractTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteContractTemplateMutation>;
+export type DeleteContractTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteContractTemplateMutation, DeleteContractTemplateMutationVariables>;
 export const CreateContractDeploymentDocument = gql`
     mutation CreateContractDeployment($projectId: UUID!, $script: String!, $signer: Address!, $arguments: [String!]) {
   createContractDeployment(
@@ -1302,7 +1297,7 @@ export const CreateContractDeploymentDocument = gql`
   }
 }
     `;
-export type CreateContractDeploymentMutationFn = Apollo.MutationFunction<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
+export type CreateContractDeploymentMutationFn = ApolloReactCommon.MutationFunction<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
 
 /**
  * __useCreateContractDeploymentMutation__
@@ -1324,13 +1319,13 @@ export type CreateContractDeploymentMutationFn = Apollo.MutationFunction<CreateC
  *   },
  * });
  */
-export function useCreateContractDeploymentMutation(baseOptions?: Apollo.MutationHookOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>) {
+export function useCreateContractDeploymentMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>(CreateContractDeploymentDocument, options);
+        return ApolloReactHooks.useMutation<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>(CreateContractDeploymentDocument, options);
       }
 export type CreateContractDeploymentMutationHookResult = ReturnType<typeof useCreateContractDeploymentMutation>;
-export type CreateContractDeploymentMutationResult = Apollo.MutationResult<CreateContractDeploymentMutation>;
-export type CreateContractDeploymentMutationOptions = Apollo.BaseMutationOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
+export type CreateContractDeploymentMutationResult = ApolloReactCommon.MutationResult<CreateContractDeploymentMutation>;
+export type CreateContractDeploymentMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateContractDeploymentMutation, CreateContractDeploymentMutationVariables>;
 export const UpdateTransactionTemplateDocument = gql`
     mutation UpdateTransactionTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateTransactionTemplate(
@@ -1343,7 +1338,7 @@ export const UpdateTransactionTemplateDocument = gql`
   }
 }
     `;
-export type UpdateTransactionTemplateMutationFn = Apollo.MutationFunction<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
+export type UpdateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
 
 /**
  * __useUpdateTransactionTemplateMutation__
@@ -1365,13 +1360,13 @@ export type UpdateTransactionTemplateMutationFn = Apollo.MutationFunction<Update
  *   },
  * });
  */
-export function useUpdateTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>) {
+export function useUpdateTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>(UpdateTransactionTemplateDocument, options);
+        return ApolloReactHooks.useMutation<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>(UpdateTransactionTemplateDocument, options);
       }
 export type UpdateTransactionTemplateMutationHookResult = ReturnType<typeof useUpdateTransactionTemplateMutation>;
-export type UpdateTransactionTemplateMutationResult = Apollo.MutationResult<UpdateTransactionTemplateMutation>;
-export type UpdateTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
+export type UpdateTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateTransactionTemplateMutation>;
+export type UpdateTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateTransactionTemplateMutation, UpdateTransactionTemplateMutationVariables>;
 export const CreateTransactionTemplateDocument = gql`
     mutation CreateTransactionTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createTransactionTemplate(
@@ -1383,7 +1378,7 @@ export const CreateTransactionTemplateDocument = gql`
   }
 }
     `;
-export type CreateTransactionTemplateMutationFn = Apollo.MutationFunction<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
+export type CreateTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
 
 /**
  * __useCreateTransactionTemplateMutation__
@@ -1404,19 +1399,19 @@ export type CreateTransactionTemplateMutationFn = Apollo.MutationFunction<Create
  *   },
  * });
  */
-export function useCreateTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>) {
+export function useCreateTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>(CreateTransactionTemplateDocument, options);
+        return ApolloReactHooks.useMutation<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>(CreateTransactionTemplateDocument, options);
       }
 export type CreateTransactionTemplateMutationHookResult = ReturnType<typeof useCreateTransactionTemplateMutation>;
-export type CreateTransactionTemplateMutationResult = Apollo.MutationResult<CreateTransactionTemplateMutation>;
-export type CreateTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
+export type CreateTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<CreateTransactionTemplateMutation>;
+export type CreateTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateTransactionTemplateMutation, CreateTransactionTemplateMutationVariables>;
 export const DeleteTransactionTemplateDocument = gql`
     mutation DeleteTransactionTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteTransactionTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteTransactionTemplateMutationFn = Apollo.MutationFunction<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
+export type DeleteTransactionTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
 
 /**
  * __useDeleteTransactionTemplateMutation__
@@ -1436,13 +1431,13 @@ export type DeleteTransactionTemplateMutationFn = Apollo.MutationFunction<Delete
  *   },
  * });
  */
-export function useDeleteTransactionTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>) {
+export function useDeleteTransactionTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>(DeleteTransactionTemplateDocument, options);
+        return ApolloReactHooks.useMutation<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>(DeleteTransactionTemplateDocument, options);
       }
 export type DeleteTransactionTemplateMutationHookResult = ReturnType<typeof useDeleteTransactionTemplateMutation>;
-export type DeleteTransactionTemplateMutationResult = Apollo.MutationResult<DeleteTransactionTemplateMutation>;
-export type DeleteTransactionTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
+export type DeleteTransactionTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteTransactionTemplateMutation>;
+export type DeleteTransactionTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteTransactionTemplateMutation, DeleteTransactionTemplateMutationVariables>;
 export const CreateTransactionExecutionDocument = gql`
     mutation CreateTransactionExecution($projectId: UUID!, $script: String!, $signers: [Address!], $arguments: [String!]) {
   createTransactionExecution(
@@ -1471,7 +1466,7 @@ export const CreateTransactionExecutionDocument = gql`
   }
 }
     `;
-export type CreateTransactionExecutionMutationFn = Apollo.MutationFunction<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
+export type CreateTransactionExecutionMutationFn = ApolloReactCommon.MutationFunction<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
 
 /**
  * __useCreateTransactionExecutionMutation__
@@ -1493,13 +1488,13 @@ export type CreateTransactionExecutionMutationFn = Apollo.MutationFunction<Creat
  *   },
  * });
  */
-export function useCreateTransactionExecutionMutation(baseOptions?: Apollo.MutationHookOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>) {
+export function useCreateTransactionExecutionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>(CreateTransactionExecutionDocument, options);
+        return ApolloReactHooks.useMutation<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>(CreateTransactionExecutionDocument, options);
       }
 export type CreateTransactionExecutionMutationHookResult = ReturnType<typeof useCreateTransactionExecutionMutation>;
-export type CreateTransactionExecutionMutationResult = Apollo.MutationResult<CreateTransactionExecutionMutation>;
-export type CreateTransactionExecutionMutationOptions = Apollo.BaseMutationOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
+export type CreateTransactionExecutionMutationResult = ApolloReactCommon.MutationResult<CreateTransactionExecutionMutation>;
+export type CreateTransactionExecutionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateTransactionExecutionMutation, CreateTransactionExecutionMutationVariables>;
 export const UpdateScripTemplateDocument = gql`
     mutation UpdateScripTemplate($projectId: UUID!, $templateId: UUID!, $script: String!, $title: String) {
   updateScriptTemplate(
@@ -1512,7 +1507,7 @@ export const UpdateScripTemplateDocument = gql`
   }
 }
     `;
-export type UpdateScripTemplateMutationFn = Apollo.MutationFunction<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
+export type UpdateScripTemplateMutationFn = ApolloReactCommon.MutationFunction<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
 
 /**
  * __useUpdateScripTemplateMutation__
@@ -1534,13 +1529,13 @@ export type UpdateScripTemplateMutationFn = Apollo.MutationFunction<UpdateScripT
  *   },
  * });
  */
-export function useUpdateScripTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>) {
+export function useUpdateScripTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>(UpdateScripTemplateDocument, options);
+        return ApolloReactHooks.useMutation<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>(UpdateScripTemplateDocument, options);
       }
 export type UpdateScripTemplateMutationHookResult = ReturnType<typeof useUpdateScripTemplateMutation>;
-export type UpdateScripTemplateMutationResult = Apollo.MutationResult<UpdateScripTemplateMutation>;
-export type UpdateScripTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
+export type UpdateScripTemplateMutationResult = ApolloReactCommon.MutationResult<UpdateScripTemplateMutation>;
+export type UpdateScripTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateScripTemplateMutation, UpdateScripTemplateMutationVariables>;
 export const CreateScriptTemplateDocument = gql`
     mutation CreateScriptTemplate($projectId: UUID!, $script: String!, $title: String!) {
   createScriptTemplate(
@@ -1552,7 +1547,7 @@ export const CreateScriptTemplateDocument = gql`
   }
 }
     `;
-export type CreateScriptTemplateMutationFn = Apollo.MutationFunction<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
+export type CreateScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
 
 /**
  * __useCreateScriptTemplateMutation__
@@ -1573,19 +1568,19 @@ export type CreateScriptTemplateMutationFn = Apollo.MutationFunction<CreateScrip
  *   },
  * });
  */
-export function useCreateScriptTemplateMutation(baseOptions?: Apollo.MutationHookOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>) {
+export function useCreateScriptTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>(CreateScriptTemplateDocument, options);
+        return ApolloReactHooks.useMutation<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>(CreateScriptTemplateDocument, options);
       }
 export type CreateScriptTemplateMutationHookResult = ReturnType<typeof useCreateScriptTemplateMutation>;
-export type CreateScriptTemplateMutationResult = Apollo.MutationResult<CreateScriptTemplateMutation>;
-export type CreateScriptTemplateMutationOptions = Apollo.BaseMutationOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
+export type CreateScriptTemplateMutationResult = ApolloReactCommon.MutationResult<CreateScriptTemplateMutation>;
+export type CreateScriptTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateScriptTemplateMutation, CreateScriptTemplateMutationVariables>;
 export const DeleteScriptTemplateDocument = gql`
     mutation DeleteScriptTemplate($projectId: UUID!, $templateId: UUID!) {
   deleteScriptTemplate(id: $templateId, projectId: $projectId)
 }
     `;
-export type DeleteScriptTemplateMutationFn = Apollo.MutationFunction<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
+export type DeleteScriptTemplateMutationFn = ApolloReactCommon.MutationFunction<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
 
 /**
  * __useDeleteScriptTemplateMutation__
@@ -1605,13 +1600,13 @@ export type DeleteScriptTemplateMutationFn = Apollo.MutationFunction<DeleteScrip
  *   },
  * });
  */
-export function useDeleteScriptTemplateMutation(baseOptions?: Apollo.MutationHookOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>) {
+export function useDeleteScriptTemplateMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>(DeleteScriptTemplateDocument, options);
+        return ApolloReactHooks.useMutation<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>(DeleteScriptTemplateDocument, options);
       }
 export type DeleteScriptTemplateMutationHookResult = ReturnType<typeof useDeleteScriptTemplateMutation>;
-export type DeleteScriptTemplateMutationResult = Apollo.MutationResult<DeleteScriptTemplateMutation>;
-export type DeleteScriptTemplateMutationOptions = Apollo.BaseMutationOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
+export type DeleteScriptTemplateMutationResult = ApolloReactCommon.MutationResult<DeleteScriptTemplateMutation>;
+export type DeleteScriptTemplateMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteScriptTemplateMutation, DeleteScriptTemplateMutationVariables>;
 export const CreateScriptExecutionDocument = gql`
     mutation CreateScriptExecution($projectId: UUID!, $script: String!, $arguments: [String!]) {
   createScriptExecution(
@@ -1637,7 +1632,7 @@ export const CreateScriptExecutionDocument = gql`
   }
 }
     `;
-export type CreateScriptExecutionMutationFn = Apollo.MutationFunction<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
+export type CreateScriptExecutionMutationFn = ApolloReactCommon.MutationFunction<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
 
 /**
  * __useCreateScriptExecutionMutation__
@@ -1658,19 +1653,19 @@ export type CreateScriptExecutionMutationFn = Apollo.MutationFunction<CreateScri
  *   },
  * });
  */
-export function useCreateScriptExecutionMutation(baseOptions?: Apollo.MutationHookOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>) {
+export function useCreateScriptExecutionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>(CreateScriptExecutionDocument, options);
+        return ApolloReactHooks.useMutation<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>(CreateScriptExecutionDocument, options);
       }
 export type CreateScriptExecutionMutationHookResult = ReturnType<typeof useCreateScriptExecutionMutation>;
-export type CreateScriptExecutionMutationResult = Apollo.MutationResult<CreateScriptExecutionMutation>;
-export type CreateScriptExecutionMutationOptions = Apollo.BaseMutationOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
+export type CreateScriptExecutionMutationResult = ApolloReactCommon.MutationResult<CreateScriptExecutionMutation>;
+export type CreateScriptExecutionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateScriptExecutionMutation, CreateScriptExecutionMutationVariables>;
 export const DeleteProjectDocument = gql`
     mutation DeleteProject($projectId: UUID!) {
   deleteProject(projectId: $projectId)
 }
     `;
-export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type DeleteProjectMutationFn = ApolloReactCommon.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
 
 /**
  * __useDeleteProjectMutation__
@@ -1689,19 +1684,19 @@ export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutat
  *   },
  * });
  */
-export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
+export function useDeleteProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, options);
+        return ApolloReactHooks.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, options);
       }
 export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
-export type DeleteProjectMutationResult = Apollo.MutationResult<DeleteProjectMutation>;
-export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
+export type DeleteProjectMutationResult = ApolloReactCommon.MutationResult<DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
 export const ResetProjectDocument = gql`
     mutation ResetProject($projectId: UUID!) {
   resetProjectState(projectId: $projectId)
 }
     `;
-export type ResetProjectMutationFn = Apollo.MutationFunction<ResetProjectMutation, ResetProjectMutationVariables>;
+export type ResetProjectMutationFn = ApolloReactCommon.MutationFunction<ResetProjectMutation, ResetProjectMutationVariables>;
 
 /**
  * __useResetProjectMutation__
@@ -1720,13 +1715,13 @@ export type ResetProjectMutationFn = Apollo.MutationFunction<ResetProjectMutatio
  *   },
  * });
  */
-export function useResetProjectMutation(baseOptions?: Apollo.MutationHookOptions<ResetProjectMutation, ResetProjectMutationVariables>) {
+export function useResetProjectMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ResetProjectMutation, ResetProjectMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<ResetProjectMutation, ResetProjectMutationVariables>(ResetProjectDocument, options);
+        return ApolloReactHooks.useMutation<ResetProjectMutation, ResetProjectMutationVariables>(ResetProjectDocument, options);
       }
 export type ResetProjectMutationHookResult = ReturnType<typeof useResetProjectMutation>;
-export type ResetProjectMutationResult = Apollo.MutationResult<ResetProjectMutation>;
-export type ResetProjectMutationOptions = Apollo.BaseMutationOptions<ResetProjectMutation, ResetProjectMutationVariables>;
+export type ResetProjectMutationResult = ApolloReactCommon.MutationResult<ResetProjectMutation>;
+export type ResetProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<ResetProjectMutation, ResetProjectMutationVariables>;
 export const SetExecutionResultsDocument = gql`
     mutation SetExecutionResults($resultType: ResultType!, $rawResult: RawExecutionResult!, $label: String) {
   updateCachedExecutionResults(
@@ -1736,7 +1731,7 @@ export const SetExecutionResultsDocument = gql`
   ) @client
 }
     `;
-export type SetExecutionResultsMutationFn = Apollo.MutationFunction<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
+export type SetExecutionResultsMutationFn = ApolloReactCommon.MutationFunction<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
 
 /**
  * __useSetExecutionResultsMutation__
@@ -1757,19 +1752,19 @@ export type SetExecutionResultsMutationFn = Apollo.MutationFunction<SetExecution
  *   },
  * });
  */
-export function useSetExecutionResultsMutation(baseOptions?: Apollo.MutationHookOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>) {
+export function useSetExecutionResultsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>(SetExecutionResultsDocument, options);
+        return ApolloReactHooks.useMutation<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>(SetExecutionResultsDocument, options);
       }
 export type SetExecutionResultsMutationHookResult = ReturnType<typeof useSetExecutionResultsMutation>;
-export type SetExecutionResultsMutationResult = Apollo.MutationResult<SetExecutionResultsMutation>;
-export type SetExecutionResultsMutationOptions = Apollo.BaseMutationOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
+export type SetExecutionResultsMutationResult = ApolloReactCommon.MutationResult<SetExecutionResultsMutation>;
+export type SetExecutionResultsMutationOptions = ApolloReactCommon.BaseMutationOptions<SetExecutionResultsMutation, SetExecutionResultsMutationVariables>;
 export const ClearExecutionResultsDocument = gql`
     mutation ClearExecutionResults($resultType: ResultType!) {
   clearCachedExecutionResults(resultType: $resultType) @client
 }
     `;
-export type ClearExecutionResultsMutationFn = Apollo.MutationFunction<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
+export type ClearExecutionResultsMutationFn = ApolloReactCommon.MutationFunction<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
 
 /**
  * __useClearExecutionResultsMutation__
@@ -1788,13 +1783,13 @@ export type ClearExecutionResultsMutationFn = Apollo.MutationFunction<ClearExecu
  *   },
  * });
  */
-export function useClearExecutionResultsMutation(baseOptions?: Apollo.MutationHookOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>) {
+export function useClearExecutionResultsMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>(ClearExecutionResultsDocument, options);
+        return ApolloReactHooks.useMutation<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>(ClearExecutionResultsDocument, options);
       }
 export type ClearExecutionResultsMutationHookResult = ReturnType<typeof useClearExecutionResultsMutation>;
-export type ClearExecutionResultsMutationResult = Apollo.MutationResult<ClearExecutionResultsMutation>;
-export type ClearExecutionResultsMutationOptions = Apollo.BaseMutationOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
+export type ClearExecutionResultsMutationResult = ApolloReactCommon.MutationResult<ClearExecutionResultsMutation>;
+export type ClearExecutionResultsMutationOptions = ApolloReactCommon.BaseMutationOptions<ClearExecutionResultsMutation, ClearExecutionResultsMutationVariables>;
 export const GetProjectsDocument = gql`
     query GetProjects {
   projectList {
@@ -1847,17 +1842,17 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(baseOptions?: Apollo.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+export function useGetProjectsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
+        return ApolloReactHooks.useQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
       }
-export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
+export function useGetProjectsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectsQuery, GetProjectsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetProjectsQuery, GetProjectsQueryVariables>(GetProjectsDocument, options);
         }
 export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
 export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
-export type GetProjectsQueryResult = Apollo.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
+export type GetProjectsQueryResult = ApolloReactCommon.QueryResult<GetProjectsQuery, GetProjectsQueryVariables>;
 export const GetProjectDocument = gql`
     query GetProject($projectId: UUID!) {
   project(id: $projectId) {
@@ -1927,17 +1922,17 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+export function useGetProjectQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
+        return ApolloReactHooks.useQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
       }
-export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
+export function useGetProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetProjectQuery, GetProjectQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetProjectQuery, GetProjectQueryVariables>(GetProjectDocument, options);
         }
 export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
 export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
-export type GetProjectQueryResult = Apollo.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
+export type GetProjectQueryResult = ApolloReactCommon.QueryResult<GetProjectQuery, GetProjectQueryVariables>;
 export const GetLocalProjectDocument = gql`
     query GetLocalProject {
   project: localProject @client {
@@ -1991,17 +1986,17 @@ export const GetLocalProjectDocument = gql`
  *   },
  * });
  */
-export function useGetLocalProjectQuery(baseOptions?: Apollo.QueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
+export function useGetLocalProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
+        return ApolloReactHooks.useQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
       }
-export function useGetLocalProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
+export function useGetLocalProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetLocalProjectQuery, GetLocalProjectQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetLocalProjectQuery, GetLocalProjectQueryVariables>(GetLocalProjectDocument, options);
         }
 export type GetLocalProjectQueryHookResult = ReturnType<typeof useGetLocalProjectQuery>;
 export type GetLocalProjectLazyQueryHookResult = ReturnType<typeof useGetLocalProjectLazyQuery>;
-export type GetLocalProjectQueryResult = Apollo.QueryResult<GetLocalProjectQuery, GetLocalProjectQueryVariables>;
+export type GetLocalProjectQueryResult = ApolloReactCommon.QueryResult<GetLocalProjectQuery, GetLocalProjectQueryVariables>;
 export const GetActiveProjectDocument = gql`
     query GetActiveProject {
   activeProjectId @client
@@ -2024,17 +2019,17 @@ export const GetActiveProjectDocument = gql`
  *   },
  * });
  */
-export function useGetActiveProjectQuery(baseOptions?: Apollo.QueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
+export function useGetActiveProjectQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
+        return ApolloReactHooks.useQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
       }
-export function useGetActiveProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
+export function useGetActiveProjectLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetActiveProjectQuery, GetActiveProjectQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetActiveProjectQuery, GetActiveProjectQueryVariables>(GetActiveProjectDocument, options);
         }
 export type GetActiveProjectQueryHookResult = ReturnType<typeof useGetActiveProjectQuery>;
 export type GetActiveProjectLazyQueryHookResult = ReturnType<typeof useGetActiveProjectLazyQuery>;
-export type GetActiveProjectQueryResult = Apollo.QueryResult<GetActiveProjectQuery, GetActiveProjectQueryVariables>;
+export type GetActiveProjectQueryResult = ApolloReactCommon.QueryResult<GetActiveProjectQuery, GetActiveProjectQueryVariables>;
 export const GetCachedExecutionResultsDocument = gql`
     query GetCachedExecutionResults {
   cachedExecutionResults @client {
@@ -2066,17 +2061,17 @@ export const GetCachedExecutionResultsDocument = gql`
  *   },
  * });
  */
-export function useGetCachedExecutionResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
+export function useGetCachedExecutionResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
+        return ApolloReactHooks.useQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
       }
-export function useGetCachedExecutionResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
+export function useGetCachedExecutionResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>(GetCachedExecutionResultsDocument, options);
         }
 export type GetCachedExecutionResultsQueryHookResult = ReturnType<typeof useGetCachedExecutionResultsQuery>;
 export type GetCachedExecutionResultsLazyQueryHookResult = ReturnType<typeof useGetCachedExecutionResultsLazyQuery>;
-export type GetCachedExecutionResultsQueryResult = Apollo.QueryResult<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>;
+export type GetCachedExecutionResultsQueryResult = ApolloReactCommon.QueryResult<GetCachedExecutionResultsQuery, GetCachedExecutionResultsQueryVariables>;
 export const GetPlaygroundInfoDocument = gql`
     query GetPlaygroundInfo {
   playgroundInfo {
@@ -2102,17 +2097,17 @@ export const GetPlaygroundInfoDocument = gql`
  *   },
  * });
  */
-export function useGetPlaygroundInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
+export function useGetPlaygroundInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
+        return ApolloReactHooks.useQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
       }
-export function useGetPlaygroundInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
+export function useGetPlaygroundInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>(GetPlaygroundInfoDocument, options);
         }
 export type GetPlaygroundInfoQueryHookResult = ReturnType<typeof useGetPlaygroundInfoQuery>;
 export type GetPlaygroundInfoLazyQueryHookResult = ReturnType<typeof useGetPlaygroundInfoLazyQuery>;
-export type GetPlaygroundInfoQueryResult = Apollo.QueryResult<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>;
+export type GetPlaygroundInfoQueryResult = ApolloReactCommon.QueryResult<GetPlaygroundInfoQuery, GetPlaygroundInfoQueryVariables>;
 export const GetExecutionResultsDocument = gql`
     query GetExecutionResults {
   cachedExecutionResults {
@@ -2153,17 +2148,17 @@ export const GetExecutionResultsDocument = gql`
  *   },
  * });
  */
-export function useGetExecutionResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
+export function useGetExecutionResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
+        return ApolloReactHooks.useQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
       }
-export function useGetExecutionResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
+export function useGetExecutionResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>(GetExecutionResultsDocument, options);
         }
 export type GetExecutionResultsQueryHookResult = ReturnType<typeof useGetExecutionResultsQuery>;
 export type GetExecutionResultsLazyQueryHookResult = ReturnType<typeof useGetExecutionResultsLazyQuery>;
-export type GetExecutionResultsQueryResult = Apollo.QueryResult<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>;
+export type GetExecutionResultsQueryResult = ApolloReactCommon.QueryResult<GetExecutionResultsQuery, GetExecutionResultsQueryVariables>;
 export const GetResultsDocument = gql`
     query GetResults {
   cachedExecutionResults {
@@ -2204,17 +2199,17 @@ export const GetResultsDocument = gql`
  *   },
  * });
  */
-export function useGetResultsQuery(baseOptions?: Apollo.QueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
+export function useGetResultsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
+        return ApolloReactHooks.useQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
       }
-export function useGetResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
+export function useGetResultsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetResultsQuery, GetResultsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
+          return ApolloReactHooks.useLazyQuery<GetResultsQuery, GetResultsQueryVariables>(GetResultsDocument, options);
         }
 export type GetResultsQueryHookResult = ReturnType<typeof useGetResultsQuery>;
 export type GetResultsLazyQueryHookResult = ReturnType<typeof useGetResultsLazyQuery>;
-export type GetResultsQueryResult = Apollo.QueryResult<GetResultsQuery, GetResultsQueryVariables>;
+export type GetResultsQueryResult = ApolloReactCommon.QueryResult<GetResultsQuery, GetResultsQueryVariables>;
 
       export interface IntrospectionResultData {
         __schema: {

--- a/src/api/apollo/mutations.ts
+++ b/src/api/apollo/mutations.ts
@@ -138,9 +138,15 @@ export const CREATE_CONTRACT_DEPLOYMENT = gql`
     $projectId: UUID!
     $script: String!
     $signer: Address!
+    $arguments: [String!]
   ) {
     createContractDeployment(
-      input: { projectId: $projectId, script: $script, address: $signer }
+      input: {
+        projectId: $projectId
+        script: $script
+        address: $signer
+        arguments: $arguments
+      }
     ) {
       id
       script

--- a/src/api/apollo/mutations.ts
+++ b/src/api/apollo/mutations.ts
@@ -337,6 +337,12 @@ export const DELETE_PROJECT = gql`
   }
 `;
 
+export const RESET_PROJECT = gql`
+  mutation ResetProject($projectId: UUID!) {
+    resetProjectState(projectId: $projectId)
+  }
+`;
+
 export const SET_EXECUTION_RESULT = gql`
   mutation SetExecutionResults(
     $resultType: ResultType!

--- a/src/api/apollo/queries.ts
+++ b/src/api/apollo/queries.ts
@@ -90,15 +90,6 @@ export const GET_PROJECT = gql`
   }
 `;
 
-export const GET_PROJECT_UPDATE_AT = gql`
-  query GetProject($projectId: UUID!) {
-    project(id: $projectId) {
-      id
-      updatedAt
-    }
-  }
-`;
-
 export const GET_LOCAL_PROJECT = gql`
   query GetLocalProject {
     project: localProject @client {

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/SingleArgument/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/SingleArgument/index.tsx
@@ -13,7 +13,7 @@ const SingleArgument: React.FC<SingleArgumentProps> = ({
   error,
   onChange,
 }) => {
-  const { name, type } = argument;
+  const { name, type, unsupported: unSupported } = argument;
   return (
     <InputBlock>
       <Label>
@@ -22,6 +22,7 @@ const SingleArgument: React.FC<SingleArgumentProps> = ({
       </Label>
       <Input
         name={`${name}-${type}`}
+        disabled={unSupported}
         onChange={(event) => {
           const { value } = event.target;
           onChange(name, value);

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/SingleArgument/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/SingleArgument/index.tsx
@@ -13,7 +13,7 @@ const SingleArgument: React.FC<SingleArgumentProps> = ({
   error,
   onChange,
 }) => {
-  const { name, type, unsupported: unSupported } = argument;
+  const { name, type, unsupported } = argument;
   return (
     <InputBlock>
       <Label>
@@ -22,7 +22,7 @@ const SingleArgument: React.FC<SingleArgumentProps> = ({
       </Label>
       <Input
         name={`${name}-${type}`}
-        disabled={unSupported}
+        disabled={unsupported}
         onChange={(event) => {
           const { value } = event.target;
           onChange(name, value);

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
@@ -172,7 +172,7 @@ export const Hints: React.FC<HintsProps> = (props: HintsProps) => {
                 onMouseOut={() => hideDecorations()}
               >
                 <ErrorIndex>
-                  <span>{`${i + 1}) `}</span>
+                  <span>{`${i + 1})`}</span>
                 </ErrorIndex>
                 <ErrorMessage>{message}</ErrorMessage>
               </SingleError>

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
@@ -149,7 +149,7 @@ export const Hints: React.FC<HintsProps> = (props: HintsProps) => {
     <Stack>
       <Heading>
         <Title>Warnings and Hints</Title>
-        <Controls onClick={toggle}>
+        <Controls onClick={toggle} style={{ paddingRight: '10px' }}>
           {hintsAmount > 0 && (
             <Badge className="info">
               <span>{hintsAmount}</span>

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/components.tsx
@@ -9,6 +9,7 @@ import {
   FaCaretSquareUp,
   FaSpinner,
 } from 'react-icons/fa';
+import CollapseOpenIcon from 'components/Icons/CollapseOpenIcon';
 import { CadenceProblem } from 'util/language-syntax-errors';
 import theme from '../../../../../theme';
 import SingleArgument from './SingleArgument';
@@ -150,15 +151,12 @@ export const Hints: React.FC<HintsProps> = (props: HintsProps) => {
         <Title>Warnings and Hints</Title>
         <Controls onClick={toggle}>
           {hintsAmount > 0 && (
-            <Badge className="green">
+            <Badge className="info">
               <span>{hintsAmount}</span>
             </Badge>
           )}
-          {expanded ? (
-            <FaCaretSquareUp cursor="pointer" opacity="0.2" />
-          ) : (
-            <FaCaretSquareDown cursor="pointer" opacity="0.2" />
-          )}
+
+          {CollapseOpenIcon()}
         </Controls>
       </Heading>
       {expanded && (
@@ -174,7 +172,7 @@ export const Hints: React.FC<HintsProps> = (props: HintsProps) => {
                 onMouseOut={() => hideDecorations()}
               >
                 <ErrorIndex>
-                  <span>{i + 1}</span>
+                  <span>{`${i + 1}) `}</span>
                 </ErrorIndex>
                 <ErrorMessage>{message}</ErrorMessage>
               </SingleError>

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
@@ -81,9 +81,11 @@ export const Badge = styled.div`
   }
 
   background-color: #ee431e;
-  &.green {
-    background-color: ${theme.colors.primary};
-    color: #222;
+  &.warning {
+    background-color: ${theme.colors.warning};
+  }
+  &.info {
+    background-color: ${theme.colors.infoBackground};
   }
 `;
 
@@ -190,11 +192,12 @@ export const SingleError = styled.div`
     background-color: rgba(244, 57, 64, 0.15);
 
     &.hint-warning {
-      background-color: rgb(238, 169, 30, 0.15);
+      //background-color: rgb(238, 169, 30, 0.15);
+      background-color: ${theme.colors.warning};
     }
 
     &.hint-info {
-      background-color: rgb(85, 238, 30, 0.15);
+      background-color: ${theme.colors.info};
     }
   }
 `;
@@ -203,6 +206,9 @@ export const ErrorIndex = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  span {
+    padding-right: 3px;
+  }
 `;
 
 export const ErrorMessage = styled.p`

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
@@ -190,15 +190,14 @@ export const SingleError = styled.div`
   border-radius: 8px;
   &:hover {
     background-color: rgba(244, 57, 64, 0.15);
+  }
+  &.hint-warning {
+    //background-color: rgb(238, 169, 30, 0.15);
+    background-color: ${theme.colors.warning};
+  }
 
-    &.hint-warning {
-      //background-color: rgb(238, 169, 30, 0.15);
-      background-color: ${theme.colors.warning};
-    }
-
-    &.hint-info {
-      background-color: ${theme.colors.info};
-    }
+  &.hint-info {
+    background-color: ${theme.colors.info};
   }
 `;
 

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/styles.tsx
@@ -192,7 +192,6 @@ export const SingleError = styled.div`
     background-color: rgba(244, 57, 64, 0.15);
   }
   &.hint-warning {
-    //background-color: rgb(238, 169, 30, 0.15);
     background-color: ${theme.colors.warning};
   }
 

--- a/src/components/Editor/CadenceEditor/ControlPanel/Arguments/types.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/Arguments/types.tsx
@@ -18,6 +18,7 @@ export type InteractionButtonProps = {
 export type Argument = {
   name: string;
   type: string;
+  unsupported: boolean;
 };
 
 export type ArgumentsProps = {

--- a/src/components/Editor/CadenceEditor/ControlPanel/components.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/components.tsx
@@ -92,9 +92,8 @@ export const Badge = styled.div`
   }
 
   background-color: #ee431e;
-  &.green {
-    background-color: ${theme.colors.primary};
-    color: #222;
+  &.warning {
+    background-color: ${theme.colors.warning};
   }
 `;
 
@@ -186,11 +185,11 @@ export const SingleError = styled.div`
     background-color: rgba(244, 57, 64, 0.15);
 
     &.hint-warning {
-      background-color: rgb(238, 169, 30, 0.15);
+      background-color: ${theme.colors.warning};
     }
 
     &.hint-info {
-      background-color: rgb(85, 238, 30, 0.15);
+      background-color: ${theme.colors.info};
     }
   }
 `;

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -385,6 +385,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
             rawResult = await contractDeployment(
               active.index,
               selectedAccountId,
+              args,
             );
             break;
           }

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -220,7 +220,6 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
     const errors = list.reduce((acc: any, item: Argument) => {
       const { name, type } = item;
       const value = values[name];
-      console.log('item', item);
       if (item.unsupported) {
         acc[name] = `Type ${type} is not supported in Playground`;
       } else if (value) {

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -32,7 +32,7 @@ import {
 
 // Component Scoped Files
 import { MotionBox, StatusIcon } from './components';
-import { ControlPanelProps, IValue } from './types';
+import { ControlPanelProps, IValue, UNSUPPORTED_TYPES } from './types';
 import {
   getLabel,
   getResultType,
@@ -58,6 +58,7 @@ import DismissiblePopup from 'components/DismissiblePopup';
 import { userModalKeys } from 'util/localstorage';
 import { addressToAccount } from 'util/accounts';
 import theme from '../../../../theme';
+import { Argument } from './Arguments/types';
 
 const ButtonActionLabels = {
   [String(EntityType.TransactionTemplate)]: 'Send',
@@ -177,7 +178,11 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
    */
   const getArguments = (): any => {
     const key = getActiveKey();
-    return executionArguments[key] || [];
+    const addSupported = (executionArguments[key] || []).map((arg: any) => ({
+      ...arg,
+      unsupported: UNSUPPORTED_TYPES.includes(arg.type),
+    }));
+    return addSupported;
   };
 
   /**
@@ -212,10 +217,13 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
    * @param values - list of argument values
    */
   const validate = (list: any, values: any) => {
-    const errors = list.reduce((acc: any, item: any) => {
+    const errors = list.reduce((acc: any, item: Argument) => {
       const { name, type } = item;
       const value = values[name];
-      if (value) {
+      console.log('item', item);
+      if (item.unsupported) {
+        acc[name] = `Type ${type} is not supported in Playground`;
+      } else if (value) {
         const error = validateByType(value, type);
         if (error) {
           acc[name] = error;

--- a/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/index.tsx
@@ -228,9 +228,7 @@ const ControlPanel: React.FC<ControlPanelProps> = (props) => {
           acc[name] = error;
         }
       } else {
-        if (type !== 'String') {
-          acc[name] = "Value can't be empty";
-        }
+        acc[name] = "Value can't be empty";
       }
       return acc;
     }, {});

--- a/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
@@ -1,6 +1,7 @@
 import { Account } from 'api/apollo/generated/graphql';
 import { editor as monacoEditor } from 'monaco-editor/esm/vs/editor/editor.api';
 
+export const UNSUPPORTED_TYPES = ['AuthAccount'];
 export interface IValue {
   [key: string]: string;
 }

--- a/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
+++ b/src/components/Editor/CadenceEditor/ControlPanel/types.tsx
@@ -21,6 +21,7 @@ export type TransactionExecution = (
 export type DeployExecution = (
   fileIndex: number,
   accountId: number,
+  args?: string[],
 ) => Promise<any>;
 
 export type ProcessingArgs = {

--- a/src/components/Icons/ResetIcon.tsx
+++ b/src/components/Icons/ResetIcon.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+function ResetIcon() {
+  return (
+    <svg
+      viewBox="0 0 21 21"
+      width="18"
+      height="18"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="#000000"
+    >
+      <g id="SVGRepo_bgCarrier" strokeWidth="0" />
+      <g
+        id="SVGRepo_tracerCarrier"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        stroke="#CCCCCC"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.75"
+          transform="matrix(0 1 1 0 2.5 2.5)"
+        >
+          <path d="m3.98652376 1.07807068c-2.38377179 1.38514556-3.98652376 3.96636605-3.98652376 6.92192932 0 4.418278 3.581722 8 8 8s8-3.581722 8-8-3.581722-8-8-8" />
+          <path d="m4 1v4h-4" transform="matrix(1 0 0 -1 0 6)" />
+        </g>
+      </g>
+      <g id="SVGRepo_iconCarrier">
+        <g
+          fill="none"
+          fillRule="evenodd"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          transform="matrix(0 1 1 0 2.5 2.5)"
+        >
+          <path d="m3.98652376 1.07807068c-2.38377179 1.38514556-3.98652376 3.96636605-3.98652376 6.92192932 0 4.418278 3.581722 8 8 8s8-3.581722 8-8-3.581722-8-8-8" />
+          <path d="m4 1v4h-4" transform="matrix(1 0 0 -1 0 6)" />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+export default ResetIcon;

--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -16,6 +16,7 @@ import { LOCAL_PROJECT_ID } from 'util/url';
 import CopyIcon from 'components/Icons/CopyIcon';
 import { Project } from 'api/apollo/generated/graphql';
 import { userDataKeys, UserLocalStorage } from 'util/localstorage';
+import ResetIcon from 'components/Icons/ResetIcon';
 
 type Props = {
   project: ProjectType;
@@ -173,12 +174,12 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
       icon: CopyIcon,
       args: [project],
     },
-    /*    {
+    {
       name: 'Reset Project',
       onClick: () => setShowResetConfirmation(true),
       icon: ResetIcon,
       args: [project],
-    }, */
+    },
   ];
   const timeAgo = formatDistance(new Date(project.updatedAt), new Date(), {
     addSuffix: true,

--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -16,7 +16,6 @@ import { LOCAL_PROJECT_ID } from 'util/url';
 import CopyIcon from 'components/Icons/CopyIcon';
 import { Project } from 'api/apollo/generated/graphql';
 import { userDataKeys, UserLocalStorage } from 'util/localstorage';
-import ResetIcon from 'components/Icons/ResetIcon';
 
 type Props = {
   project: ProjectType;

--- a/src/components/LeftSidebar/ProjectListItem.tsx
+++ b/src/components/LeftSidebar/ProjectListItem.tsx
@@ -16,6 +16,7 @@ import { LOCAL_PROJECT_ID } from 'util/url';
 import CopyIcon from 'components/Icons/CopyIcon';
 import { Project } from 'api/apollo/generated/graphql';
 import { userDataKeys, UserLocalStorage } from 'util/localstorage';
+import ResetIcon from 'components/Icons/ResetIcon';
 
 type Props = {
   project: ProjectType;
@@ -74,6 +75,12 @@ const confirmDeleteOptions = {
   ],
 };
 
+const confirmResetOptions = {
+  title: `Reset this project?`,
+  messages: [
+    'Are you sure you want to reset all emulator state for this project? This cannot be undone.',
+  ],
+};
 const infoLastProjectOptions = {
   title: `Unable to delete this project!`,
   messages: ['At least one playground project is required.'],
@@ -89,19 +96,23 @@ const willLoseChangesOptions = {
 const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
   const userStorage = new UserLocalStorage();
   const [doingAction, setDoingAction] = useState<boolean>(false);
-  const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
+  const [showDelConfirmation, setShowDelConfirmation] =
+    useState<boolean>(false);
+  const [showResetConfirmation, setShowResetConfirmation] =
+    useState<boolean>(false);
   const [showLastProject, setShowLastProject] = useState<boolean>(false);
   const [showWillLoseChanges, setShowWillLoseChanges] =
     useState<boolean>(false);
   const {
     toggleProjectsSidebar,
     deleteProject,
+    resetProject,
     project: activeProject,
     copyProject,
   } = useProject();
 
   const confirmDelete = async (isConfirmed: boolean): Promise<void> => {
-    setShowConfirmation(false);
+    setShowDelConfirmation(false);
     if (isConfirmed) {
       setDoingAction(true);
       try {
@@ -110,6 +121,19 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
           userStorage.setData(userDataKeys.PROJECT_ID, null);
         }
         await deleteProject(project.id);
+        await refetch();
+      } finally {
+        setDoingAction(false);
+      }
+    }
+  };
+
+  const confirmReset = async (isConfirmed: boolean): Promise<void> => {
+    setShowResetConfirmation(false);
+    if (isConfirmed) {
+      setDoingAction(true);
+      try {
+        await resetProject(project.id);
         await refetch();
       } finally {
         setDoingAction(false);
@@ -139,7 +163,9 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
     {
       name: 'Delete Project',
       onClick: () =>
-        projectCount > 1 ? setShowConfirmation(true) : setShowLastProject(true),
+        projectCount > 1
+          ? setShowDelConfirmation(true)
+          : setShowLastProject(true),
       icon: DeleteIcon,
     },
     {
@@ -148,6 +174,12 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
       icon: CopyIcon,
       args: [project],
     },
+    /*    {
+      name: 'Reset Project',
+      onClick: () => setShowResetConfirmation(true),
+      icon: ResetIcon,
+      args: [project],
+    }, */
   ];
   const timeAgo = formatDistance(new Date(project.updatedAt), new Date(), {
     addSuffix: true,
@@ -167,8 +199,13 @@ const ProjectListItem = ({ project, projectCount, refetch }: Props) => {
     <Flex sx={rootStyles}>
       <ConfirmationPopup
         onClose={confirmDelete}
-        visible={showConfirmation}
+        visible={showDelConfirmation}
         {...confirmDeleteOptions}
+      />
+      <ConfirmationPopup
+        onClose={confirmReset}
+        visible={showResetConfirmation}
+        {...confirmResetOptions}
       />
       <InformationalPopup
         onClose={setShowLastProject}

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -254,7 +254,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     let res;
     try {
       // TODO - reset project
-      console.log('reset project');
+      console.log('reset project', dProjectId);
       res = null; //await mutator.deleteProject(dProjectId);
     } catch (e) {
       console.error(e);

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -253,9 +253,8 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     setIsSaving(true);
     let res;
     try {
-      // TODO - reset project
-      console.log('reset project', dProjectId);
-      res = null; //await mutator.deleteProject(dProjectId);
+      res = null;
+      await mutator.resetProject(dProjectId);
     } catch (e) {
       console.error(e);
       checkAppErrors();

--- a/src/providers/Project/index.tsx
+++ b/src/providers/Project/index.tsx
@@ -39,6 +39,7 @@ export interface ProjectContextValue {
   ) => Promise<any>;
   saveProject: () => Promise<any>;
   deleteProject: (projectId: string) => Promise<any>;
+  resetProject: (projectId: string) => Promise<any>;
   createContractDeployment: (
     fileIndex: number,
     accountId: number,
@@ -248,9 +249,27 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
     return res;
   };
 
+  const resetProject = async (dProjectId: string) => {
+    setIsSaving(true);
+    let res;
+    try {
+      // TODO - reset project
+      console.log('reset project');
+      res = null; //await mutator.deleteProject(dProjectId);
+    } catch (e) {
+      console.error(e);
+      checkAppErrors();
+    } finally {
+      setIsSaving(false);
+    }
+
+    return res;
+  };
+
   const createContractDeployment: any = async (
     fileIndex: number,
     accountId: number,
+    args: string[] = [],
   ) => {
     setIsSaving(true);
     setIsExecutingAction(true);
@@ -262,6 +281,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         template,
         deployAccount,
         active.index,
+        args,
       );
 
       const addr = deployAccount.address;
@@ -812,6 +832,7 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({
         updateProject,
         saveProject,
         deleteProject,
+        resetProject,
         createContractDeployment,
         updateContractTemplate,
         updateScriptTemplate,

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -19,6 +19,7 @@ import {
   DELETE_PROJECT,
   DELETE_SCRIPT_TEMPLATE,
   DELETE_TRANSACTION_TEMPLATE,
+  RESET_PROJECT,
   SAVE_PROJECT,
   SET_ACTIVE_PROJECT,
   UPDATE_CONTRACT_TEMPLATE,
@@ -29,7 +30,6 @@ import {
   GET_APPLICATION_ERRORS,
   GET_LOCAL_PROJECT,
   GET_PROJECT,
-  GET_PROJECT_UPDATE_AT,
 } from 'api/apollo/queries';
 
 import Mixpanel from 'util/mixpanel';
@@ -319,6 +319,20 @@ export default class ProjectMutator {
     return res;
   }
 
+  async resetProject(projectId: string) {
+    const res = await this.client.mutate({
+      mutation: RESET_PROJECT,
+      variables: {
+        projectId,
+      },
+      refetchQueries: [{ query: GET_PROJECT, variables: { projectId } }],
+      context: {
+        serializationKey: PROJECT_SERIALIZATION_KEY,
+      },
+    });
+    return res;
+  }
+
   async updateTransactionTemplate(
     templateId: string,
     script: string,
@@ -349,7 +363,7 @@ export default class ProjectMutator {
       },
       refetchQueries: [
         {
-          query: GET_PROJECT_UPDATE_AT,
+          query: GET_PROJECT,
           variables: { projectId: this.projectId },
         },
       ],
@@ -477,7 +491,7 @@ export default class ProjectMutator {
       },
       refetchQueries: [
         {
-          query: GET_PROJECT_UPDATE_AT,
+          query: GET_PROJECT,
           variables: { projectId: this.projectId },
         },
       ],
@@ -729,7 +743,7 @@ export default class ProjectMutator {
       },
       refetchQueries: [
         {
-          query: GET_PROJECT_UPDATE_AT,
+          query: GET_PROJECT,
           variables: { projectId: this.projectId },
         },
       ],

--- a/src/providers/Project/projectMutator.ts
+++ b/src/providers/Project/projectMutator.ts
@@ -745,6 +745,7 @@ export default class ProjectMutator {
     contractTemplate: ContractTemplate,
     account: Account,
     index: number,
+    args: string[],
   ) {
     const hasDeployedCode = !!account.deployedContracts?.length;
 
@@ -761,6 +762,7 @@ export default class ProjectMutator {
         projectId: this.projectId,
         script: contractTemplate.script,
         signer: account.address,
+        arguments: args,
       },
       refetchQueries: [
         { query: GET_PROJECT, variables: { projectId: this.projectId } },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -23,6 +23,8 @@ export default {
     borderDark: 'rgb(222, 222, 222)',
     shadowColor: 'rgb(222, 222, 222)',
     warning: '#ffcc00',
+    info: '#55EE1E26',
+    infoBackground: '#55EE1E',
     error: '#f44336',
     errorToast: '#fc4723',
     blue: '#0000ff',

--- a/src/util/normalize-interaction-response.ts
+++ b/src/util/normalize-interaction-response.ts
@@ -75,7 +75,6 @@ export const normalizeInteractionResponse = (response: any): Line[] => {
   if (respIsCreateContractDeployment(response)) {
     const lines = [];
     const scoped = response.data.createContractDeployment;
-
     const addresses = scoped.events
       .filter(
         (event: { type: string }) =>
@@ -91,7 +90,7 @@ export const normalizeInteractionResponse = (response: any): Line[] => {
       .filter(Boolean);
 
     const items = makeEventValues(scoped.events);
-    for (let d of scoped.logs) lines.push(makeLine(Tag.LOG, d));
+    for (let d of scoped.logs || []) lines.push(makeLine(Tag.LOG, d));
     addresses.forEach((address: string) =>
       lines.push(
         makeLine(Tag.LOG, `Deployed Contract To: 0x${address.slice(-2)}`),
@@ -104,7 +103,7 @@ export const normalizeInteractionResponse = (response: any): Line[] => {
   if (respIsCreateTransactionExecution(response)) {
     const scoped = response.data.createTransactionExecution;
     const lines = [];
-    for (let d of scoped.logs) lines.push(makeLine(Tag.LOG, d));
+    for (let d of scoped.logs || []) lines.push(makeLine(Tag.LOG, d));
     const items = makeEventValues(scoped.events);
     if (scoped.errors && scoped.errors.length)
       lines.push(
@@ -119,7 +118,7 @@ export const normalizeInteractionResponse = (response: any): Line[] => {
   if (respIsCreateScriptExecution(response)) {
     const scoped = response.data.createScriptExecution;
     const lines = [];
-    for (let d of scoped.logs) lines.push(makeLine(Tag.LOG, d));
+    for (let d of scoped.logs || []) lines.push(makeLine(Tag.LOG, d));
     if (scoped.errors && scoped.errors.length)
       lines.push(
         makeLine(


### PR DESCRIPTION
Closes: #690 
Closes: #708 


## Description

 - Hint from language server to inform user AuthAccount is an anti-pattern.
 - Disable inputs for unsupported arguments.
 - Style tweaks

![image](https://github.com/onflow/flow-playground/assets/3970376/0a86e384-509f-4b1e-8729-28fa6424f529)

Give user ability to reset a project state.

![Screenshot 2023-06-22 at 10 51 27 AM](https://github.com/onflow/flow-playground/assets/3970376/c5aef296-3cd4-49a8-92d7-5c93b4ba2159)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

