### PR TITLE
check for active.index is -1

### DIFF
--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -108,7 +108,8 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
         accountNumber == '0x01'
           ? `${accountNumber}-Default`
           : `${accountNumber}`;
-      script = active.index !== -1 ? project.accounts[active.index].state : "{}";
+      script =
+        active.index !== -1 ? project.accounts[active.index].state : '{}';
   }
 
   const [isCopied, setCopied] = useClipboard(script, {

--- a/src/components/Editor/EditorPanels.tsx
+++ b/src/components/Editor/EditorPanels.tsx
@@ -108,7 +108,7 @@ const EditorPanels = ({ show }: EditorPanelsProps) => {
         accountNumber == '0x01'
           ? `${accountNumber}-Default`
           : `${accountNumber}`;
-      script = project.accounts[active.index].state;
+      script = active.index !== -1 ? project.accounts[active.index].state : "{}";
   }
 
   const [isCopied, setCopied] = useClipboard(script, {

--- a/src/components/LeftSidebar/NewProjectButton.tsx
+++ b/src/components/LeftSidebar/NewProjectButton.tsx
@@ -5,7 +5,7 @@ import Button, { ButtonProps } from '../Button';
 import PlusIcon from '../Icons/PlusIcon';
 import Tooltip from '../Tooltip';
 
-export const MAX_PROJECTS = 10;
+export const MAX_PROJECTS = 50;
 
 type NewProjectButtonProps = {
   label?: string;


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/732

## Description

some projects use accounts that are no longer available on playground, in this case the UI blanks out.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

