### PR TITLE
add upgrade cadence 1.0 banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hotjar/browser": "^1.0.6",
         "@ibm/plex": "^6.1.1",
         "@mdx-js/react": "^2.3.0",
-        "@onflow/cadence-language-server": "^0.33.3",
+        "@onflow/cadence-language-server": "0.33.3",
         "@reach/router": "^1.3.4",
         "@sentry/integrations": "^7.44.0",
         "@sentry/react": "^7.44.0",

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,12 +1,12 @@
 import { Project } from 'api/apollo/generated/graphql';
 import CookieDetector from 'components/BrowserDetector';
 import FileExplorer from 'components/Editor/FileExplorer';
-import TopNav from 'components/TopNav';
 import UnsupportedMessage from 'components/UnsupportedBrowser';
 import { EditorContainer } from 'containers/Playground/components';
 import { ActiveEditor } from 'providers/Project';
 import React from 'react';
 import ErrorToastContainer from './ErrorToastContainer';
+import Header from 'components/TopNav/Header';
 
 const { detect } = require('detect-browser');
 const browser = detect();
@@ -17,6 +17,7 @@ type EditorContainerProps = {
   isLoading: boolean;
   project: Project;
   active: ActiveEditor;
+  isAnnouncementVisible: boolean;
 };
 
 const Editor = ({
@@ -25,13 +26,15 @@ const Editor = ({
   isLoading,
   project,
   active,
+  isAnnouncementVisible,
 }: EditorContainerProps) => {
+
   return (
     <>
       {browser && browser.name === 'safari' ? (
         <UnsupportedMessage />
       ) : (
-        <TopNav />
+        <Header isAnnouncementVisible={isAnnouncementVisible}/>
       )}
       <CookieDetector />
       <FileExplorer

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -28,13 +28,12 @@ const Editor = ({
   active,
   isAnnouncementVisible,
 }: EditorContainerProps) => {
-
   return (
     <>
       {browser && browser.name === 'safari' ? (
         <UnsupportedMessage />
       ) : (
-        <Header isAnnouncementVisible={isAnnouncementVisible}/>
+        <Header isAnnouncementVisible={isAnnouncementVisible} />
       )}
       <CookieDetector />
       <FileExplorer

--- a/src/components/TopNav/Announcement.tsx
+++ b/src/components/TopNav/Announcement.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { SXStyles } from 'src/types';
+import { Box, Flex, Link } from 'theme-ui';
+
+const Announcement = () => {
+
+  const styles: SXStyles = {
+    root: {
+      backgroundColor: 'white',
+      flex: '1 1 auto',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      background: '#F27360',
+      width: '100%',
+      padding: '0.5rem',
+      height: '60px'
+    },
+    message: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      textAlign: 'center',
+      color: '#585F71',
+      fontSize: '14px',
+      padding: '0.15rem',
+    },
+    devLink: {
+        textDecoration: 'underline',
+        color: '#585F71',
+    },
+  };
+
+  return (
+    <Flex sx={styles.root}>
+      <Box sx={styles.message}>⚠ Upgrade to Cadence 1.0</Box>
+      <Box sx={styles.message}>
+        The Crescendo network upgrade, including Cadence 1.0, is coming soon.
+        You most likely need to update all your contracts/transactions/scripts
+        to support this change.
+      </Box>
+      <Box sx={styles.message}>
+        Please visit our migration guide here:&nbsp;&nbsp;
+        <Link
+          sx={styles.devLink}
+          target="_blank"
+          href="https://developers.flow.com/build/cadence-migration-guide"
+          rel="noreferrer"
+          title="Report a Bug"
+        >
+          https://developers.flow.com/build/cadence-migration-guide
+        </Link>
+      </Box>
+    </Flex>
+  );
+};
+
+export default Announcement;

--- a/src/components/TopNav/Announcement.tsx
+++ b/src/components/TopNav/Announcement.tsx
@@ -15,7 +15,7 @@ const Announcement = () => {
       justifyContent: 'space-between',
       background: '#F27360',
       width: '100%',
-      padding: '0.5rem',
+      padding: '0.25rem 0 0.5rem',
       height: '60px',
       color: `${theme.colors.secondary}`,
     },

--- a/src/components/TopNav/Announcement.tsx
+++ b/src/components/TopNav/Announcement.tsx
@@ -3,9 +3,9 @@ import { SXStyles } from 'src/types';
 import { Box, Flex, Link, useThemeUI } from 'theme-ui';
 
 const Announcement = () => {
-    const context = useThemeUI();
-    const { theme } = context;
-  
+  const context = useThemeUI();
+  const { theme } = context;
+
   const styles: SXStyles = {
     root: {
       backgroundColor: 'white',
@@ -29,8 +29,8 @@ const Announcement = () => {
       padding: '0.15rem',
     },
     devLink: {
-        textDecoration: 'underline',
-        color: `${theme.colors.secondary}`,
+      textDecoration: 'underline',
+      color: `${theme.colors.secondary}`,
     },
   };
 

--- a/src/components/TopNav/Announcement.tsx
+++ b/src/components/TopNav/Announcement.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { SXStyles } from 'src/types';
-import { Box, Flex, Link } from 'theme-ui';
+import { Box, Flex, Link, useThemeUI } from 'theme-ui';
 
 const Announcement = () => {
-
+    const context = useThemeUI();
+    const { theme } = context;
+  
   const styles: SXStyles = {
     root: {
       backgroundColor: 'white',
@@ -14,20 +16,21 @@ const Announcement = () => {
       background: '#F27360',
       width: '100%',
       padding: '0.5rem',
-      height: '60px'
+      height: '60px',
+      color: `${theme.colors.secondary}`,
     },
     message: {
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       textAlign: 'center',
-      color: '#585F71',
+      color: `${theme.colors.secondary}`,
       fontSize: '14px',
       padding: '0.15rem',
     },
     devLink: {
         textDecoration: 'underline',
-        color: '#585F71',
+        color: `${theme.colors.secondary}`,
     },
   };
 

--- a/src/components/TopNav/Header.tsx
+++ b/src/components/TopNav/Header.tsx
@@ -4,21 +4,24 @@ import TopNav from '.';
 import { isMobile } from '../Editor/CadenceEditor/ControlPanel/utils';
 
 const headerStyle = {
-    display: 'flex',
-    gridArea: 'header',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'left',
+  display: 'flex',
+  gridArea: 'header',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'left',
 };
 
-const Header = ({isAnnouncementVisible}: {isAnnouncementVisible: boolean}) => {
-    return (
-      <header style={headerStyle}>
-        {!isMobile() && isAnnouncementVisible && <AnnouncementBar />}
-        <TopNav />
-
-      </header>
-    );
+const Header = ({
+  isAnnouncementVisible,
+}: {
+  isAnnouncementVisible: boolean;
+}) => {
+  return (
+    <header style={headerStyle}>
+      {!isMobile() && isAnnouncementVisible && <AnnouncementBar />}
+      <TopNav />
+    </header>
+  );
 };
 
 export default Header;

--- a/src/components/TopNav/Header.tsx
+++ b/src/components/TopNav/Header.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import AnnouncementBar from './Announcement';
+import TopNav from '.';
+import { isMobile } from '../Editor/CadenceEditor/ControlPanel/utils';
+
+const headerStyle = {
+    display: 'flex',
+    gridArea: 'header',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'left',
+};
+
+const Header = ({isAnnouncementVisible}: {isAnnouncementVisible: boolean}) => {
+    return (
+      <header style={headerStyle}>
+        {!isMobile() && isAnnouncementVisible && <AnnouncementBar />}
+        <TopNav />
+
+      </header>
+    );
+};
+
+export default Header;

--- a/src/components/TopNav/Header.tsx
+++ b/src/components/TopNav/Header.tsx
@@ -3,10 +3,10 @@ import AnnouncementBar from './Announcement';
 import TopNav from '.';
 import { isMobile } from '../Editor/CadenceEditor/ControlPanel/utils';
 
-const headerStyle = {
+const headerStyle: React.CSSProperties = {
   display: 'flex',
   gridArea: 'header',
-  flexDirection: 'column',
+  flexDirection: 'column' as 'column',
   alignItems: 'center',
   justifyContent: 'left',
 };

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -33,13 +33,13 @@ const TopNav = () => {
   const styles: SXStyles = {
     root: {
       display: 'flex',
-      gridArea: 'header',
       flex: '1 1 auto',
       alignItems: 'center',
       justifyContent: 'space-between',
       paddingLeft: '1em',
       paddingRight: '1em',
       background: `${theme.colors.primary}`,
+      width: '100%',
     },
     mobile: {
       background: `${theme.colors.secondaryBackground}`,

--- a/src/containers/Playground/EditorLayout.tsx
+++ b/src/containers/Playground/EditorLayout.tsx
@@ -7,11 +7,13 @@ import Editor from '../../components/Editor/index';
 type EditorLayoutProps = {
   isExplorerCollapsed: boolean;
   toggleExplorer: () => void;
+  isAnnouncementVisible: boolean;
 };
 
 const EditorLayout = ({
   isExplorerCollapsed,
   toggleExplorer,
+  isAnnouncementVisible,
 }: EditorLayoutProps) => {
   const { project, isLoading, active } = useProject();
 
@@ -54,6 +56,7 @@ const EditorLayout = ({
         isLoading={isLoading}
         project={project}
         active={active}
+        isAnnouncementVisible={isAnnouncementVisible}
       />
     </>
   );

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -37,13 +37,15 @@ const closeLeftSidebarButtonStyle: CSSProperties = {
   zIndex: 10,
 };
 
+const isAnnouncementVisible = true;
+
 const getBaseStyles = (
   showProjectsSidebar: boolean,
   isExplorerCollapsed: boolean,
 ): ThemeUICSSObject => {
   const fileExplorerWidth = isExplorerCollapsed
     ? isMobile()
-      ? '30px'
+      ? '50px'
       : '65px'
     : '244px';
 
@@ -57,7 +59,7 @@ const getBaseStyles = (
     display: 'grid',
     gridTemplateAreas: "'header header' 'sidebar main'",
     gridTemplateColumns: `[sidebar] ${fileExplorerWidth} [main] auto`,
-    gridTemplateRows: ['40px auto', '50px auto'],
+    gridTemplateRows: isAnnouncementVisible ? ['40px auto', '105px auto'] : ['40px auto', '50px auto'],
     overflow: 'hidden',
     filter: showProjectsSidebar ? 'blur(1px)' : 'none',
   };
@@ -115,6 +117,7 @@ const Content = () => {
           <EditorLayout
             isExplorerCollapsed={isExplorerCollapsed}
             toggleExplorer={toggleExplorer}
+            isAnnouncementVisible={isAnnouncementVisible}
           />
         </Box>
       </motion.div>

--- a/src/containers/Playground/index.tsx
+++ b/src/containers/Playground/index.tsx
@@ -59,7 +59,9 @@ const getBaseStyles = (
     display: 'grid',
     gridTemplateAreas: "'header header' 'sidebar main'",
     gridTemplateColumns: `[sidebar] ${fileExplorerWidth} [main] auto`,
-    gridTemplateRows: isAnnouncementVisible ? ['40px auto', '105px auto'] : ['40px auto', '50px auto'],
+    gridTemplateRows: isAnnouncementVisible
+      ? ['40px auto', '105px auto']
+      : ['40px auto', '50px auto'],
     overflow: 'hidden',
     filter: showProjectsSidebar ? 'blur(1px)' : 'none',
   };


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-playground/issues/758

## Description

Add upgrade Cadence 1.0 banner for desktop. Not adding to mobile since it's readonly.
![image](https://github.com/onflow/flow-playground/assets/3970376/c3cd421e-82f7-4a27-9ec0-86f78fbdef6e)

![image](https://github.com/onflow/flow-playground/assets/3970376/1a8672c1-69f8-4ddc-99f9-6678ca4e06c1)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

