### PR TITLE
Added auto-closing brackets

### DIFF
--- a/src/components/Editor/CadenceEditor/index.tsx
+++ b/src/components/Editor/CadenceEditor/index.tsx
@@ -174,6 +174,9 @@ const CadenceEditor = (props: CadenceEditorProps) => {
       readOnly: project.active.type === EntityType.AccountStorage || isMobile(),
       domReadOnly: isMobile(),
       contextmenu: !isMobile(),
+      autoClosingBrackets: 'languageDefined',
+      autoClosingQuotes: 'languageDefined',
+      autoSurround: 'languageDefined',
     });
 
     const [code] = project.getActiveCode();

--- a/src/util/cadence.ts
+++ b/src/util/cadence.ts
@@ -13,6 +13,27 @@ export default function configureCadence() {
     aliases: ['CDC', 'cdc'],
   });
 
+  // Configure brackets and auto-closing pairs for the Cadence language
+  monaco.languages.setLanguageConfiguration(CADENCE_LANGUAGE_ID, {
+    brackets: [
+      ['{', '}'],
+      ['[', ']'],
+      ['(', ')'],
+    ],
+    autoClosingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+      { open: '"', close: '"', notIn: ['string'] },
+    ],
+    surroundingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+      { open: '"', close: '"' },
+    ],
+  });
+
   const languageDef: IMonarchLanguage & {
     keywords: string[];
     typeKeywords: string[];


### PR DESCRIPTION


## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds autoclosing brackets and quotes in the Cadence editor.

- Enables language-defined auto-closing and auto-surround in the editor.
- Configures Cadence language brackets, autoClosingPairs, and surroundingPairs.

Most critical files to review:
- [src/util/cadence.ts](cci:7://file:///Users/rohitpurkait/Work/Personal/oss/flow-playground/src/util/cadence.ts:0:0-0:0) — adds `setLanguageConfiguration` with brackets/pairs.
- [src/components/Editor/CadenceEditor/index.tsx](cci:7://file:///Users/rohitpurkait/Work/Personal/oss/flow-playground/src/components/Editor/CadenceEditor/index.tsx:0:0-0:0) — enables `autoClosingBrackets`, `autoClosingQuotes`, `autoSurround` in editor options.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels