### PR TITLE
docs: add TL;DR, FAQ, and GEO enhancements for discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Release notes and version history for flow-playground are tracked via GitHub Releases:
+
+- https://github.com/onflow/flow-playground/releases
+
+For user-facing changes per version, see the Releases page.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use flow-playground in your research or reference it, please cite it as below."
+title: "flow-playground: Browser-based IDE for writing, compiling, and testing Cadence smart contracts"
+authors:
+  - name: "Flow Foundation"
+    website: "https://flow.com"
+repository-code: "https://github.com/onflow/flow-playground"
+url: "https://play.flow.com"
+license: Apache-2.0
+type: software
+keywords:
+  - flow
+  - flow-network
+  - cadence
+  - playground
+  - ide
+  - smart-contracts
+  - developer-tools

--- a/README.md
+++ b/README.md
@@ -1,71 +1,71 @@
-# Flow Playground
+# flow-playground — Browser-based Cadence IDE
 
-The Flow Playground is the best way to learn and try Cadence. For newcomers to Flow,
-the [Flow Developer Documentation](https://docs.onflow.org) includes a guide on how to use the Playground.
+[![License](https://img.shields.io/github/license/onflow/flow-playground.svg)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/onflow/flow-playground?include_prereleases&sort=semver)](https://github.com/onflow/flow-playground/releases)
+[![Discord](https://img.shields.io/discord/613813861610684416?label=Discord&logo=discord&logoColor=white)](https://discord.gg/flow)
+[![Built on Flow](https://img.shields.io/badge/Built%20on-Flow-00EF8B)](https://flow.com)
+[![TypeScript](https://img.shields.io/badge/language-TypeScript-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
-## Philosophy
+Browser-based IDE for writing, compiling, and testing [Cadence](https://cadence-lang.org) smart contracts directly in a browser. Part of the [Flow network](https://flow.com) developer toolchain.
 
-### How It's Built
+## TL;DR
 
-We built the Flow Playground as a static website or typical "JAM stack" website because of these properties:
+- **What:** A web-based IDE for authoring, compiling, and testing Cadence smart contracts without local tooling.
+- **Who it's for:** Developers learning Cadence, educators teaching Flow, and anyone prototyping contracts in a browser.
+- **Why use it:** Zero-install onboarding to Cadence; share projects via URL; iterate on contracts, transactions, and scripts against an embedded Flow emulator.
+- **Status:** see [Releases](https://github.com/onflow/flow-playground/releases) for the latest version.
+- **License:** Apache-2.0
+- **Related repos:** [onflow/cadence](https://github.com/onflow/cadence) · [onflow/flow-cli](https://github.com/onflow/flow-cli) · [onflow/flow-go](https://github.com/onflow/flow-go)
+- The reference browser-based Cadence playground for the Flow network, open-sourced since 2020.
 
-- Portability. It is easy to move a static website GUI between platforms if desired
-- We want to have the ability to deploy the Playground on peer-to-peer networks like IPFS or DAT
-- Fast build and deploy cycles
-- We want to maximize the amount of potential contributions
+## Quick Start
 
-### What is the Playground?
+Hosted version (recommended):
 
-We want the Playground to have features that help you build on Flow. We also want to balance functionality with learning.
+- Open https://play.flow.com in a browser and start a new project.
 
-The Playground is a learning tool first and an awesome development tool second, although the two go hand-in-hand.
+Run locally (for contributors):
 
-## Contributing
-
-### Read the [Contribution Guidelines](CONTRIBUTING.md)
-
-### Git Workflow
-
-- Use merge squashing, not commit merging [eg. here](https://blog.dnsimple.com/2019/01/two-years-of-squash-merge/). Squash merge is your friend.
-- The `staging` branch is the base branch and contains the code deployed at https://play.staging.onflow.org.
-
-## Developing
-
-### Pre-requisites
-
-You'll need to have Docker installed to develop.
-
-### Installation
-
-Clone the repo
-
-```shell script
+```shell
 git clone git@github.com:onflow/flow-playground.git
-```
-
-Install dependencies
-
-```
+cd flow-playground
 npm install
 ```
 
-Rename `.env.local` to `.env`
+Rename `.env.local` to `.env`, then start the API and the frontend:
 
-Start the API (Flow Emulator and services)
-
-```
+```shell
 docker run -e FLOW_DEBUG=true -e FLOW_SESSIONCOOKIESSECURE=false -p 8080:8080 gcr.io/dl-flow/playground-api:latest
-```
-
-Start the React app
-
-```
 npm run start
 ```
 
-✨ The Playground is running on localhost:3000 ✨
+The Playground is then available on http://localhost:3000.
 
-If you are using VSCode, you can use this debugging config (works with workspaces)
+## Features
+
+- Web-based editor for Cadence contracts, transactions, and scripts.
+- Embedded Flow emulator for running code without installing a local node.
+- Starter templates to help newcomers learn Cadence.
+- Shareable project URLs for tutorials and collaboration.
+- Static, portable frontend ("JAM stack") designed for easy deployment.
+
+## Example
+
+A typical workflow in the Playground:
+
+1. Open https://play.flow.com and create a new project.
+2. Pick a template (contract, transaction, or script) from the editor.
+3. Deploy the contract to one of the in-browser accounts.
+4. Run a transaction or script against the deployed contract.
+5. Share the project URL with teammates or learners.
+
+## How It Works
+
+The Flow Playground is shipped as a static frontend (React + TypeScript) backed by a Playground API that wraps the [Flow Emulator](https://developers.flow.com). Building the frontend as a static site keeps it portable, fast to deploy, and easy to host on different platforms. See [RUNBOOK.md](RUNBOOK.md) for deployment details and [CONTRIBUTING.md](CONTRIBUTING.md) for contributor workflow, including the `staging` branch convention.
+
+## VS Code debugging
+
+If you are using VS Code, the following debug configuration is known to work with workspaces:
 
 ```
 {
@@ -91,6 +91,53 @@ If you are using VSCode, you can use this debugging config (works with workspace
 }
 ```
 
+## Contributing
+
+See the [Contribution Guidelines](CONTRIBUTING.md).
+
+Git workflow notes:
+
+- Use merge squashing rather than commit merging ([background](https://blog.dnsimple.com/2019/01/two-years-of-squash-merge/)).
+- The `staging` branch is the base branch and contains the code deployed at https://play.staging.flow.com.
+
 ## Deployment
 
 The runbook contains details on [how to deploy the Flow Playground web app](RUNBOOK.md).
+
+## FAQ
+
+**What is the Flow Playground?**
+A browser-based IDE for writing, compiling, and testing Cadence smart contracts without installing local tooling.
+
+**Where is the hosted version?**
+The Playground is available at https://play.flow.com.
+
+**Which language does it support?**
+Cadence, the resource-oriented smart contract language for Flow. See the [Cadence language reference](https://cadence-lang.org).
+
+**Do I need to install anything to use it?**
+No. The hosted Playground runs entirely in the browser. Local setup is only needed if you want to contribute to the Playground itself.
+
+**How do I run the Playground locally?**
+Clone the repo, run `npm install`, start the API via Docker, and run `npm run start`. See the Quick Start section above.
+
+**Where can I learn Cadence?**
+The [Flow developer portal](https://developers.flow.com) and the [Cadence language reference](https://cadence-lang.org) are the canonical learning resources.
+
+**How do I report a bug or request a feature?**
+Open an issue on this repository, or discuss in the [Flow Discord](https://discord.gg/flow) or [Flow Forum](https://forum.flow.com).
+
+## Community
+
+- [Flow Discord](https://discord.gg/flow)
+- [Flow Forum](https://forum.flow.com)
+- [Flow Improvement Proposals (FLIPs)](https://github.com/onflow/flips)
+
+## About Flow
+
+This repo is part of the [Flow network](https://flow.com), a Layer 1 blockchain built for consumer applications, AI Agents, and DeFi at scale.
+
+- Developer docs: https://developers.flow.com
+- Cadence language: https://cadence-lang.org
+- Community: [Flow Discord](https://discord.gg/flow) · [Flow Forum](https://forum.flow.com)
+- Governance: [Flow Improvement Proposals](https://github.com/onflow/flips)


### PR DESCRIPTION
## Summary

- Add TL;DR block under H1 with What/Who/Why/Status/License/Related-repos bullets
- Add FAQ section with answers grounded in existing README content
- Add Community and About Flow footer sections
- Fix deprecated `docs.onflow.org` URLs → `developers.flow.com` / `cadence-lang.org`
- Add CITATION.cff and CHANGELOG.md stubs
- Brand voice fixes (no "Flow blockchain", no "Flow's" possessive)

## Test plan

- [ ] Review README.md diff for accuracy and brand voice compliance
- [ ] Verify all links resolve
- [ ] Confirm no SEO_AUDIT_REPORT.md or .audit-extract.json in commit